### PR TITLE
Wildcard arr logs

### DIFF
--- a/jail.d/prowlarr-auth.conf
+++ b/jail.d/prowlarr-auth.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2022/08/11
 # Fail2Ban jail configuration for prowlarr
 # Works OOTB with defaults
 
@@ -6,5 +6,5 @@
 
 enabled  = false
 port     = 9696
-logpath  = %(remote_logs_path)s/prowlarr/prowlarr.txt
+logpath  = %(remote_logs_path)s/prowlarr/prowlarr*.txt
 filter   = servarr-auth

--- a/jail.d/radarr-auth.conf
+++ b/jail.d/radarr-auth.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2022/08/11
 # Fail2Ban jail configuration for radarr
 # Works OOTB with defaults
 
@@ -6,5 +6,5 @@
 
 enabled  = false
 port     = 7878
-logpath  = %(remote_logs_path)s/radarr/radarr.txt
+logpath  = %(remote_logs_path)s/radarr/radarr*.txt
 filter   = servarr-auth

--- a/jail.d/sonarr-auth.conf
+++ b/jail.d/sonarr-auth.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2022/08/11
 # Fail2Ban jail configuration for sonarr
 # Works OOTB with defaults
 
@@ -6,5 +6,5 @@
 
 enabled  = false
 port     = 8989
-logpath  = %(remote_logs_path)s/sonarr/sonarr.txt
+logpath  = %(remote_logs_path)s/sonarr/sonarr*.txt
 filter   = servarr-auth


### PR DESCRIPTION
*arr apps do numbered log files. ex:
```
sonarr.txt
sonarr.1.txt
sonarr.2.txt
```
This should allow checking any of those files.

After this merges, we can modify the readme
https://github.com/linuxserver/docker-fail2ban/blob/7b612f44bc848c2e2b584fe602617b2262bd61e4/readme-vars.yml#L53
to point to the folder instead of the file.