### PR TITLE
Sab regex

### DIFF
--- a/filter.d/sabnzbd-auth.conf
+++ b/filter.d/sabnzbd-auth.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2022/08/11
 # Fail2Ban filter configuration for sabnzbd
 
 [INCLUDES]
@@ -6,6 +6,15 @@ before = common.conf
 
 [Definition]
 
-failregex = ^.*(Unsuccessful login attempt from|Refused connection( with hostname "<HOST>")? from:|(API Key missing|API Key incorrect|Authentication missing).* your 3rd party program:) (?:\(X-Forwarded-For: (<HOST>)(?:,[^']*)?\)|(<HOST>)) \[.*\]$
+failregex = ^.*API Key incorrect, Use the api key from Config->General in your 3rd party program: .* \(X-Forwarded-For: <HOST>\) \[[^\]*]\]$
+            ^.*API Key incorrect, Use the api key from Config->General in your 3rd party program: <HOST> \[[^\]*]\]$
+            ^.*API Key missing, please enter the api key from Config->General into your 3rd party program: .* \(X-Forwarded-For: <HOST>\) \[[^\]*]\]$
+            ^.*API Key missing, please enter the api key from Config->General into your 3rd party program: <HOST> \[[^\]*]\]$
+            ^.*Refused connection from: .* \(X-Forwarded-For: <HOST>\) \[[^\]*]\]$
+            ^.*Refused connection from: <HOST> \[[^\]*]\]$
+            ^.*Refused connection with hostname "[^"]*" from: .* \(X-Forwarded-For: <HOST>\) \[[^\]*]\]$
+            ^.*Refused connection with hostname "[^"]*" from: <HOST> \[[^\]*]\]$
+            ^.*Unsuccessful login attempt from .* \(X-Forwarded-For: <HOST>\) \[[^\]*]\]$
+            ^.*Unsuccessful login attempt from <HOST> \[[^\]*]\]$
 
 ignoreregex =


### PR DESCRIPTION
Using https://github.com/sabnzbd/sabnzbd/blob/develop/sabnzbd/interface.py as reference.
Original combined regex caused failure. New split regex is tested and does not cause failure.