### PR TITLE
Initial commit

### DIFF
--- a/action.d/opnsense.conf
+++ b/action.d/opnsense.conf
@@ -1,0 +1,82 @@
+## Version 2022/08/16
+#
+# Fail2Ban action configuration for OPNsense
+# Author: https://linuxserver.io/
+#
+# Please ensure jail.local permission are secure (640) as it contains your OPNsense API key
+#
+# OPNsense API Key/Secret guide: https://docs.opnsense.org/development/how-tos/api.html
+#
+# This action maintains an OPNsense HOST group alias.
+#
+# Configure OPNsense with:
+# 							A correctly named empty HOST group alias.
+# 							An associated firewall rule.
+#
+# In most instances the OPNsense rule will likely take the form of a INBOUND WAN DROP but specifics are left to user discretion.
+#
+# WARNING:	This action allows connections to default OPNsense installs deployed with self signed TLS certificates.
+# 			If required disable this via a .local action file removing the curl -k switch.
+#
+
+[Definition]
+
+# Option:  actionstart
+# Notes.:  command executed once at the start of Fail2Ban.
+# Values:  CMD
+#
+#actionstart = 
+
+# Option:  actionstop
+# Notes.:  command executed once at the end of Fail2Ban
+# Values:  CMD
+#
+#actionstop = 
+
+# Option:  actioncheck
+# Notes.:  command executed once before each actionban command
+# Values:  CMD
+#
+#actioncheck = 
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionban = curl -k -s -XPOST -d '{"address":"<ip>"}' -H "Content-Type: application/json" -k -u "<key>":"<secret>" https://<firewall>/api/firewall/alias_util/add/<alias>
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionunban = curl -k -s -XPOST -d '{"address":"<ip>"}' -H "Content-Type: application/json" -k -u "<key>":"<secret>" https://<firewall>/api/firewall/alias_util/delete/<alias>
+
+[Init]
+
+# Option:  alias
+# Notes.:  The OPNsense host group name to add the Fail2ban IP to.
+# Values:  [ STRING ]
+#
+alias =
+
+# Option:  firewall
+# Notes.:  Your OPNsense IP or DNS name.
+# Values:  [ STRING ]
+#
+firewall =
+
+# Option:  key
+# Notes.:  Your OPNsense user key.
+# Values:  [ STRING ]
+#
+key = 
+
+# Option:  secret
+# Notes.:  Your OPNsense user secret.
+# Values:  [ STRING ]
+#
+secret =


### PR DESCRIPTION
This action allows fail2ban to send IP bans directly to OPNsense by maintaining a host alias group. This group can then be used by the user in any way they see fit directly within OPNsense e.g. to block traffic. 

There is no necessity to disable the default fail2ban host iptables action in jail.local but when successfully deployed this action will likely result in these chains never needing to actually block traffic.

This approach can be useful when you have:

- multiple hosts requiring protection
- fragile hosts that are not easy to filter directly

It may also be useful when host cap_add options are not accessible (TBC)
