### PR TITLE
Gotify: Use bantime action variable iso time

### DIFF
--- a/action.d/gotify.conf
+++ b/action.d/gotify.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/10
+## Version 2022/12/18
 # Fail2Ban configuration file
 #
 # Author: Quietsy

--- a/action.d/gotify.conf
+++ b/action.d/gotify.conf
@@ -37,7 +37,7 @@ actioncheck =
 # Values:  CMD
 #
 actionban = curl -X POST -H Content-Type:application/json <url> \
-	--data '{"message": "⛔ <name> ⛔\n\n<ip> got banned for <time> seconds after <failures> tries.\n\nUnban command:\nfail2ban-client unban <ip>"}'
+	--data '{"message": "⛔ <name> ⛔\n\n<ip> got banned for <bantime> seconds after <failures> tries.\n\nUnban command:\nfail2ban-client unban <ip>"}'
     
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the


### PR DESCRIPTION
The time variable indicated the moment of banning. Within the context of the message the bantime variable should be used, indicating the ban duration.


