### PR TITLE
Fix allow_insecure handling

### DIFF
--- a/action.d/opnsense.conf
+++ b/action.d/opnsense.conf
@@ -56,7 +56,7 @@ actionban = curl <_allow_insecure> -s -XPOST -d '{"address":"<ip>"}' -H "Content
 actionunban = curl <_allow_insecure> -s -XPOST -d '{"address":"<ip>"}' -H "Content-Type: application/json" -u "<key>":"<secret>" https://<firewall>/api/firewall/alias_util/delete/<alias>
 
 # Internal variable handler for `allow_insecure`
-_allow_insecure = if [ '<allow_insecure>' = true ]; then echo ' -k '; fi;
+_allow_insecure = $(if [ '<allow_insecure>' = true ]; then echo ' -k '; else echo ''; fi;)
 
 [Init]
 


### PR DESCRIPTION
This fixes the allow_insecure setting which was silently breaking all OPNsense API calls

Credit to @nemchik 