### PR TITLE
Fix Emby matching

### DIFF
--- a/filter.d/emby-auth.conf
+++ b/filter.d/emby-auth.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2023/03/11
 # Fail2Ban filter for emby
 
 [INCLUDES]
@@ -8,14 +8,6 @@ before = common.conf
 
 _daemon = emby-server
 
-failregex = ^.*Info HttpServer: HTTP Response 401 to <HOST>.*authenticatebyname.*$
-            ^.*Info HttpServer: HTTP Response 500 to <HOST>.*mediabrowser/Users/None.*$
+failregex = Server: AUTH-ERROR:\ <HOST>\ - 
 
 ignoreregex =
-
-# DEV Notes:
-#
-# Matching on http 401 with a trailing url including 'authenticatebyname' to catch incorrect passwords
-# Matching on http 500 with a trailing url including 'mediabrowser/Users/None' to catch incorrect usernames
-#
-# Author: everydayevil@everydayevil.com


### PR DESCRIPTION
It is unknown when it happened but the existing fail2ban Emby filter no longer matches any failed login requests of any type in testing here. This simplified match catches the new? `AUTH-ERROR` log.