### PR TITLE
Create traefik-404.conf

### DIFF
--- a/filter.d/traefik-404.conf
+++ b/filter.d/traefik-404.conf
@@ -1,0 +1,15 @@
+## Version 2023/03/06
+# Fail2Ban filter configuration for traefik 404
+# Count 404 hits as potential threat actors e.g. bots blind scanning or DNS walking
+# WARNING: This is an extremely aggressive filer.
+#          Unless you are certain you need it you almost certainly do not.
+#          ignoreip's are required as you WILL see false positives.
+
+[INCLUDES]
+
+before = common.conf
+
+[Definition]
+
+failregex = ^<HOST>.*"(GET|POST|HEAD).*HTTP\/[0-9]+(.[0-9]+)?"\ (404)\ .*$
+ignoreregex =


### PR DESCRIPTION
This filter is realistically useful only within small Traefik deployments such as self-hosting. Use in large deployments will see legitimate users routinely blocked and systems intentionally open to the public should not even be considered.

It can however prove to be a useful tool in small user-base stable systems as it will routinely catch and block an impressive amount of unknown users and bots, many of which will be bad actors.