### PR TITLE
Fix Home Assistant filtering

### DIFF
--- a/filter.d/homeassistant-auth.conf
+++ b/filter.d/homeassistant-auth.conf
@@ -6,7 +6,7 @@ before = common.conf
 
 [Definition]
 
-failregex = ^%(__prefix_line)s.*\[homeassistant.components.http.ban\] Login attempt or request with invalid authentication from <HOST>.*$
+failregex = ^%(__prefix_line)s.*\[homeassistant.components.http.ban\] Login attempt or request with invalid authentication from.*\(<HOST>\).*$
 
 ignoreregex =
 


### PR DESCRIPTION
```
2024-09-19 22:20:07.019 WARNING (MainThread) [homeassistant.components.http.ban] Login attempt or request with invalid authentication from ip0-0-0-0.example.com (0.0.0.0). Requested URL: '/auth/login_flow/0bd5b90aa77f40ad8a3e42528c9278d7'. (Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36)
```