### PR TITLE
Sync all fail2ban config files with upstream (2025)

### DIFF
--- a/action.d/abuseipdb.conf
+++ b/action.d/abuseipdb.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/05/20
 # Fail2ban configuration file
 #
 # Action to report IP address to abuseipdb.com
@@ -81,7 +81,7 @@ actioncheck =
 #          use my (Shaun's) helper PHP script by commenting out the first #actionban
 #          line below, uncommenting the second one, and pointing the URL at
 #          wherever you install the helper script. For the PHP helper script, see
-#          <https://wiki.shaunc.com/wikka.php?wakka=ReportingToAbuseIPDBWithFail2Ban>
+#          <https://github.com/parseword/fail2ban-abuseipdb/>
 #
 # Tags:    See jail.conf(5) man page
 # Values:  CMD

--- a/action.d/apprise.conf
+++ b/action.d/apprise.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/09/02
 # Fail2Ban configuration file
 #
 # Author: Chris Caron <lead2gold@gmail.com>
@@ -11,7 +11,7 @@
 # Notes.:  command executed once at the start of Fail2Ban.
 # Values:  CMD
 #
-actionstart = printf %%b "The jail <name> as been started successfully." | <apprise> -t "[Fail2Ban] <name>: started on `uname -n`"
+actionstart = printf %%b "The jail <name> has been started successfully." | <apprise> -t "[Fail2Ban] <name>: started on `uname -n`"
 
 # Option:  actionstop
 # Notes.:  command executed once at the end of Fail2Ban

--- a/action.d/blocklist_de.conf
+++ b/action.d/blocklist_de.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2019/06/29
 # Fail2Ban configuration file
 #
 # Author: Steven Hiscocks
@@ -30,6 +30,9 @@
 #
 
 [Definition]
+
+# bypass reporting of restored (already reported) tickets:
+norestored = 1
 
 # Option:  actionstart
 # Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).

--- a/action.d/bsd-ipfw.conf
+++ b/action.d/bsd-ipfw.conf
@@ -81,7 +81,7 @@ block = ip
 # Option:  blocktype
 # Notes.:  How to block the traffic. Use a action from man 5 ipfw
 #          Common values: deny, unreach port, reset
-#          ACTION defination at the top of man ipfw for allowed values.
+#          ACTION definition at the top of man ipfw for allowed values.
 # Values:  STRING
 #
 blocktype = unreach port

--- a/action.d/cloudflare-token.conf
+++ b/action.d/cloudflare-token.conf
@@ -1,4 +1,4 @@
-## Version 2022/12/15
+## Version 2025/03/01
 #
 # Author: Logic-32
 #
@@ -51,11 +51,12 @@ actionban = curl -s -X POST "<_cf_api_url>" \
 #          <time>  unix timestamp of the ban time
 # Values:  CMD
 #
-actionunban = id=$(curl -s -X GET "<_cf_api_url>?mode=<cfmode>&notes=<notes>&configuration.target=<cftarget>&configuration.value=<ip>" \
-                       <_cf_api_prms> \
-                       | awk -F"[,:}]" '{for(i=1;i<=NF;i++){if($i~/'id'\042/){print $(i+1)}}}' \
-                       | tr -d ' "' \
-                       | head -n 1)
+actionunban = id=$(curl -s -G -X GET "<_cf_api_url>" \
+              --data-urlencode "mode=<cfmode>" --data-urlencode "notes=<notes>" --data-urlencode "configuration.target=<cftarget>" --data-urlencode "configuration.value=<ip>" \
+              <_cf_api_prms> \
+                  | awk -F"[,:}]" '{for(i=1;i<=NF;i++){if($i~/'id'\042/){print $(i+1)}}}' \
+                  | tr -d ' "' \
+                  | head -n 1)
               if [ -z "$id" ]; then echo "<name>: id for <ip> cannot be found using target <cftarget>"; exit 0; fi; \
               curl -s -X DELETE "<_cf_api_url>/$id" \
                   <_cf_api_prms> \

--- a/action.d/complain.conf
+++ b/action.d/complain.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2023/11/22
 # Fail2Ban configuration file
 #
 # Author: Russell Odom <russ@gloomytrousers.co.uk>, Daniel Black
@@ -17,7 +17,7 @@
 #
 # Please do not use this action unless you are certain that fail2ban
 # does not result in "false positives" for your deployment.  False
-# positive reports could serve a mis-favor to the original cause by
+# positive reports could serve a misfavor to the original cause by
 # flooding corresponding contact addresses, and complicating the work
 # of administration personnel responsible for handling (verified) legit
 # complains.

--- a/action.d/firewallcmd-ipset.conf
+++ b/action.d/firewallcmd-ipset.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/11/07
 # Fail2Ban action file for firewall-cmd/ipset
 #
 # This requires:
@@ -19,36 +19,36 @@ before = firewallcmd-common.conf
 
 [Definition]
 
-actionstart = <ipstype_<ipsettype>/actionstart>
+actionstart = <ipsbackend_<ipsetbackend>/actionstart>
               firewall-cmd --direct --add-rule <family> filter <chain> 0 <actiontype> -m set --match-set <ipmset> src -j <blocktype>
 
-actionflush = <ipstype_<ipsettype>/actionflush>
+actionflush = <ipsbackend_<ipsetbackend>/actionflush>
 
 actionstop = firewall-cmd --direct --remove-rule <family> filter <chain> 0 <actiontype> -m set --match-set <ipmset> src -j <blocktype>
              <actionflush>
-             <ipstype_<ipsettype>/actionstop>
+             <ipsbackend_<ipsetbackend>/actionstop>
 
-actionban = <ipstype_<ipsettype>/actionban>
+actionban = <ipsbackend_<ipsetbackend>/actionban>
 
 # actionprolong = %(actionban)s
 
-actionunban = <ipstype_<ipsettype>/actionunban>
+actionunban = <ipsbackend_<ipsetbackend>/actionunban>
 
-[ipstype_ipset]
+[ipsbackend_ipset]
 
-actionstart = ipset -exist create <ipmset> hash:ip timeout <default-ipsettime> <familyopt>
+actionstart = ipset -exist create <ipmset> <ipsettype> timeout <default-ipsettime> maxelem <maxelem> <familyopt>
 
 actionflush = ipset flush <ipmset>
 
-actionstop = ipset destroy <ipmset>
+actionstop = ipset destroy <ipmset> 2>/dev/null || { sleep 1; ipset destroy <ipmset>; }
 
 actionban = ipset -exist add <ipmset> <ip> timeout <ipsettime>
 
 actionunban = ipset -exist del <ipmset> <ip>
 
-[ipstype_firewalld]
+[ipsbackend_firewalld]
 
-actionstart = firewall-cmd --direct --new-ipset=<ipmset> --type=hash:ip --option=timeout=<default-ipsettime> <firewalld_familyopt>
+actionstart = firewall-cmd --direct --new-ipset=<ipmset> --type=<ipsettype> --option=timeout=<default-ipsettime> --option=maxelem=<maxelem> <firewalld_familyopt>
 
 # TODO: there doesn't seem to be an explicit way to invoke the ipset flush function using firewall-cmd
 actionflush = 
@@ -60,6 +60,11 @@ actionban = firewall-cmd --ipset=<ipmset> --add-entry=<ip>
 actionunban = firewall-cmd --ipset=<ipmset> --remove-entry=<ip>
 
 [Init]
+
+# Option: ipsettype
+# Notes:  specifies type of set, see `man --pager='less -p "^SET TYPES"' ipset` for details
+# Values: hash:ip, hash:net, etc... Default: hash:ip
+ipsettype = hash:ip
 
 # Option:  chain
 # Notes    specifies the iptables chain to which the fail2ban rules should be
@@ -78,15 +83,21 @@ default-ipsettime = 0
 # Values:  [ NUM ]  Default: 0 (managed by fail2ban by unban)
 ipsettime = 0
 
-# expresion to caclulate timeout from bantime, example:
+# Option: maxelem
+# Notes:  maximal number of elements which can be stored in the ipset
+#         You may want to increase this for long-duration/high-volume jails
+# Values: [ NUM ] Default: 65536
+maxelem = 65536
+
+# expression to calculate timeout from bantime, example:
 # banaction = %(known/banaction)s[ipsettime='<timeout-bantime>']
 timeout-bantime = $([ "<bantime>" -le 2147483 ] && echo "<bantime>" || echo 0)
 
-# Option: ipsettype
-# Notes.: defines type of ipset used for match-set (firewalld or ipset)
+# Option: ipsetbackend
+# Notes.: defines the backend of ipset used for match-set (firewalld or ipset)
 # Values: firewalld or ipset
 # Default: ipset
-ipsettype = ipset
+ipsetbackend = ipset
 
 # Option: actiontype
 # Notes.: defines additions to the blocking rule
@@ -119,4 +130,4 @@ firewalld_familyopt = --option=family=inet6
 # DEV NOTES:
 #
 # Author: Edgar Hoch, Daniel Black, Sergey Brester and Mihail Politaev
-# firewallcmd-new / iptables-ipset-proto6 combined for maximium goodness
+# firewallcmd-new / iptables-ipset-proto6 combined for maximum goodness

--- a/action.d/firewallcmd-rich-rules.conf
+++ b/action.d/firewallcmd-rich-rules.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/08/07
 # Fail2Ban configuration file
 #
 # Author: Donald Yandt 
@@ -36,7 +36,7 @@ actioncheck =
 #
 # Because rich rules can only handle single or a range of ports we must split ports and execute the command for each port. Ports can be single and ranges separated by a comma or space for an example: http, https, 22-60, 18 smtp 
 
-fwcmd_rich_rule = rule family='<family>' source address='<ip>' port port='$p' protocol='<protocol>' %(rich-suffix)s
+fwcmd_rich_rule = rule family=\"<family>\" source address=\"<ip>\" port port=\"$p\" protocol=\"<protocol>\" %(rich-suffix)s
 
 actionban = ports="<port>"; for p in $(echo $ports | tr ", " " "); do firewall-cmd --add-rich-rule="%(fwcmd_rich_rule)s"; done
 	   

--- a/action.d/iptables-ipset-proto4.conf
+++ b/action.d/iptables-ipset-proto4.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2023/11/18
 # Fail2Ban configuration file
 #
 # Author: Daniel Black
@@ -28,7 +28,7 @@ before = iptables.conf
 # Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
 # Values:  CMD
 #
-actionstart = ipset --create f2b-<name> iphash
+actionstart = ipset --create f2b-<name> maxelem <maxelem> iphash
               <_ipt_add_rules>
 
 
@@ -62,6 +62,14 @@ actionban = ipset --test f2b-<name> <ip> ||  ipset --add f2b-<name> <ip>
 #
 actionunban = ipset --test f2b-<name> <ip> && ipset --del f2b-<name> <ip>
 
-# Several capabilities used internaly:
+# Several capabilities used internally:
 
 rule-jump = -m set --match-set f2b-<name> src -j <blocktype>
+
+[Init]
+
+# Option: maxelem
+# Notes:  maximal number of elements which can be stored in the ipset
+#         You may want to increase this for long-duration/high-volume jails
+# Values: [ NUM ] Default: 65536
+maxelem = 65536

--- a/action.d/iptables-ipset.conf
+++ b/action.d/iptables-ipset.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/11/07
 # Fail2Ban configuration file
 #
 # Authors: Sergey G Brester (sebres), Daniel Black, Alexander Koeppe
@@ -25,7 +25,7 @@ before = iptables.conf
 # Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
 # Values:  CMD
 #
-actionstart = ipset -exist create <ipmset> hash:ip timeout <default-ipsettime> <familyopt>
+actionstart = ipset -exist create <ipmset> <ipsettype> timeout <default-ipsettime> maxelem <maxelem> <familyopt>
               <_ipt_add_rules>
 
 # Option:  actionflush
@@ -40,7 +40,7 @@ actionflush = ipset flush <ipmset>
 #
 actionstop = <_ipt_del_rules>
              <actionflush>
-             ipset destroy <ipmset>
+             ipset destroy <ipmset> 2>/dev/null || { sleep 1; ipset destroy <ipmset>; }
 
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
@@ -60,12 +60,17 @@ actionban = ipset -exist add <ipmset> <ip> timeout <ipsettime>
 #
 actionunban = ipset -exist del <ipmset> <ip>
 
-# Several capabilities used internaly:
+# Several capabilities used internally:
 
 rule-jump = -m set --match-set <ipmset> src -j <blocktype>
 
 
 [Init]
+
+# Option: ipsettype
+# Notes:  specifies type of set, see `man --pager='less -p "^SET TYPES"' ipset` for details
+# Values: hash:ip, hash:net, etc... Default: hash:ip
+ipsettype = hash:ip
 
 # Option: default-ipsettime
 # Notes:  specifies default timeout in seconds (handled default ipset timeout only)
@@ -77,7 +82,13 @@ default-ipsettime = 0
 # Values:  [ NUM ]  Default: 0 (managed by fail2ban by unban)
 ipsettime = 0
 
-# expresion to caclulate timeout from bantime, example:
+# Option: maxelem
+# Notes:  maximal number of elements which can be stored in the ipset
+#         You may want to increase this for long-duration/high-volume jails
+# Values: [ NUM ] Default: 65536
+maxelem = 65536
+
+# expression to calculate timeout from bantime, example:
 # banaction = %(known/banaction)s[ipsettime='<timeout-bantime>']
 timeout-bantime = $([ "<bantime>" -le 2147483 ] && echo "<bantime>" || echo 0)
 

--- a/action.d/iptables-new.conf
+++ b/action.d/iptables-new.conf
@@ -1,4 +1,3 @@
-## Version 2022/08/06
 # Fail2Ban configuration file
 #
 # Author: Cyril Jaquier

--- a/action.d/iptables-xt_recent-echo.conf
+++ b/action.d/iptables-xt_recent-echo.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2025/04/16
 # Fail2Ban configuration file
 #
 # Author: Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>
@@ -13,8 +13,9 @@ before = iptables.conf
 [Definition]
 
 _ipt_chain_rule = -m recent --update --seconds 3600 --name <iptname> -j <blocktype>
-_ipt_for_proto-iter =
-_ipt_for_proto-done =
+_ipt_check_rule = <iptables> -C <chain> %(_ipt_chain_rule)s
+_ipt-iter =
+_ipt-done =
 
 # Option:  actionstart
 # Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
@@ -61,7 +62,7 @@ actionstop = echo / > /proc/net/xt_recent/<iptname>
 # Notes.:  command executed as invariant check (error by ban)
 # Values:  CMD
 #
-actioncheck = { <iptables> -C <chain> %(_ipt_chain_rule)s; } && test -e /proc/net/xt_recent/<iptname>
+actioncheck = { %(_ipt_check_rule)s >/dev/null 2>&1; } && test -e /proc/net/xt_recent/<iptname>
 
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the

--- a/action.d/iptables.conf
+++ b/action.d/iptables.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2025/04/16
 # Fail2Ban configuration file
 #
 # Authors: Sergey G. Brester (sebres), Cyril Jaquier, Daniel Black, 
@@ -63,25 +63,25 @@ pre-rule =
 
 rule-jump = -j <_ipt_rule_target>
 
-# Several capabilities used internaly:
+# Several capabilities used internally:
 
-_ipt_for_proto-iter = for proto in $(echo '<protocol>' | sed 's/,/ /g'); do
-_ipt_for_proto-done = done
+_ipt-iter = for chain in $(echo '<chain>' | sed 's/,/ /g'); do for proto in $(echo '<protocol>' | sed 's/,/ /g'); do
+_ipt-done = done; done
 
-_ipt_add_rules = <_ipt_for_proto-iter>
-              { %(_ipt_check_rule)s >/dev/null 2>&1; } || { <iptables> -I <chain> %(_ipt_chain_rule)s; }
-              <_ipt_for_proto-done>
+_ipt_add_rules = <_ipt-iter>
+              { %(_ipt_check_rule)s >/dev/null 2>&1; } || { <iptables> -I $chain %(_ipt_chain_rule)s; }
+              <_ipt-done>
 
-_ipt_del_rules = <_ipt_for_proto-iter>
-              <iptables> -D <chain> %(_ipt_chain_rule)s
-              <_ipt_for_proto-done>
+_ipt_del_rules = <_ipt-iter>
+              <iptables> -D $chain %(_ipt_chain_rule)s
+              <_ipt-done>
 
-_ipt_check_rules = <_ipt_for_proto-iter>
+_ipt_check_rules = <_ipt-iter>
               %(_ipt_check_rule)s
-              <_ipt_for_proto-done>
+              <_ipt-done>
 
 _ipt_chain_rule = <pre-rule><ipt_<type>/_chain_rule>
-_ipt_check_rule = <iptables> -C <chain> %(_ipt_chain_rule)s
+_ipt_check_rule = <iptables> -C $chain %(_ipt_chain_rule)s
 _ipt_rule_target = f2b-<name>
 
 [ipt_oneport]
@@ -100,8 +100,9 @@ _chain_rule = -p $proto <rule-jump>
 [Init]
 
 # Option:  chain
-# Notes    specifies the iptables chain to which the Fail2Ban rules should be
-#          added
+# Notes    specifies the iptables chains to which the Fail2Ban rules should be
+#          added. May be a single chain (e.g. INPUT) or a comma separated list
+#          (e.g. INPUT, FORWARD)
 # Values:  STRING  Default: INPUT
 chain = INPUT
 
@@ -136,7 +137,7 @@ returntype = RETURN
 
 # Option:  lockingopt
 # Notes.:  Option was introduced to iptables to prevent multiple instances from
-#          running concurrently and causing irratic behavior.  -w was introduced
+#          running concurrently and causing erratic behavior.  -w was introduced
 #          in iptables 1.4.20, so might be absent on older systems
 #          See https://github.com/fail2ban/fail2ban/issues/1122
 # Values:  STRING

--- a/action.d/ipthreat.conf
+++ b/action.d/ipthreat.conf
@@ -1,4 +1,4 @@
-## Version 2022/12/15
+## Version 2023/11/22
 # IPThreat configuration file
 #
 # Added to fail2ban by Jeff Johnson (jjxtra)
@@ -16,7 +16,7 @@
 # Reporting an IP is a serious action. Make sure that it is legit.
 # Consider using this action only for:
 #   * IP that has been banned more than once
-#   * High max retry to avoid user mis-typing password
+#   * High max retry to avoid user mistyping password
 #   * Filters that are unlikely to be human error
 #
 # Example:
@@ -48,7 +48,7 @@
 # BadBot         256     Bad bot that is not honoring robots.txt or just flooding with too many requests, etc
 # Compromised    512     The ip has been taken over by malware or botnet
 # Phishing       1024    The ip is involved in phishing or spoofing
-# Iot            2048    The ip has targetted an iot (Internet of Things) device
+# Iot            2048    The ip has targeted an iot (Internet of Things) device
 # PortScan       4096    Port scan
 # See https://ipthreat.net/bulkreportformat for more information
 # ```

--- a/action.d/mikrotik.conf
+++ b/action.d/mikrotik.conf
@@ -1,0 +1,85 @@
+## Version 2023/03/08
+# Fail2Ban configuration file
+#
+# Mikrotik routerOS action to add/remove address-list entries
+#
+# Author: Duncan Bellamy <dunk@denkimushi.com>
+# based on forum.mikrotik.com post by pakjebakmeel
+#
+# in the instructions:
+# (10.0.0.1 is ip of mikrotik router)
+# (10.0.0.2 is ip of fail2ban machine)
+#
+# on fail2ban machine:
+# sudo mkdir /var/lib/fail2ban/ssh
+# sudo chmod 700 /var/lib/fail2ban/ssh
+# sudo ssh-keygen -N "" -f /var/lib/fail2ban/ssh/fail2ban_id_rsa
+# sudo scp /var/lib/fail2ban/ssh/fail2ban_id_rsa.pub admin@10.0.0.1:/
+# ssh admin@10.0.0.1
+#
+# on mikrotik router:
+# /user add name=miki-f2b group=write address=10.0.0.2 password=""
+# /user ssh-keys import public-key-file=fail2ban_id_rsa.pub user=miki-f2b
+# /quit
+#
+# on fail2ban machine:
+# (check password login fails)
+# ssh miki-f2b@10.0.0.1
+# (check private key works)
+# sudo ssh -i /var/lib/fail2ban/ssh/fail2ban_id_rsa miki-f2b@10.0.0.1
+#
+# Then create rules on mikrorik router that use address
+# list(s) maintained by fail2ban eg in the forward chain
+# drop from address list, or in the forward chain drop
+# from address list to server
+#
+# example extract from jail.local overriding some defaults
+# action = mikrotik[keyfile="%(mkeyfile)s", user="%(muser)s", host="%(mhost)s", list="%(mlist)s"]
+#
+# ignoreip = 127.0.0.1/8 192.168.0.0/24
+
+# mkeyfile = /etc/fail2ban/ssh/mykey_id_rsa
+# muser = myuser
+# mhost = 192.168.0.1
+# mlist = BAD LIST
+
+[Definition]
+
+actionstart =
+
+actionstop = %(actionflush)s
+
+actionflush = %(command)s "/ip firewall address-list remove [find list=\"%(list)s\" comment~\"%(startcomment)s-*\"]"
+
+actioncheck =
+
+actionban = %(command)s "/ip firewall address-list add list=\"%(list)s\" address=<ip> comment=%(comment)s"
+
+actionunban = %(command)s "/ip firewall address-list remove [find list=\"%(list)s\" comment=%(comment)s]"
+
+command = ssh -l %(user)s -p%(port)s -i %(keyfile)s %(host)s
+
+# Option: user
+# Notes.: username to use when connecting to routerOS
+user =
+# Option: port
+# Notes.: port to use when connecting to routerOS
+port = 22
+# Option: keyfile
+# Notes.: ssh private key to use for connecting to routerOS
+keyfile =
+# Option: host
+# Notes.: hostname or ip of router
+host =
+# Option: list
+# Notes.: name of "address-list" to use on router
+list = Fail2Ban
+# Option: startcomment
+# Notes.: used as a prefix to all comments, and used to match for flushing rules
+startcomment = f2b-<name>
+# Option: comment
+# Notes.: comment to use on routerOS (must be unique as used for ip address removal)
+comment = %(startcomment)s-<ip>
+
+[Init]
+name="%(__name__)s"

--- a/action.d/netscaler.conf
+++ b/action.d/netscaler.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2023/11/18
 # Fail2ban Citrix Netscaler Action
 # by Juliano Jeziorny
 # juliano@jeziorny.eu
@@ -6,7 +6,7 @@
 # The script will add offender IPs to a dataset on netscaler, the dataset can then be used to block the IPs at a cs/vserver or global level
 # This dataset is then used to block IPs using responder policies on the netscaler.
 # 
-# The script assumes using HTTPS with unsecure certificate to access the netscaler, 
+# The script assumes using HTTPS with insecure certificate to access the netscaler, 
 # if you have a valid certificate installed remove the -k from the curl lines, or if you want http change it accordingly (and remove the -k)
 # 
 # This action depends on curl

--- a/action.d/nftables.conf
+++ b/action.d/nftables.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2025/08/08
 # Fail2Ban configuration file
 #
 # Author: Daniel Black
@@ -45,7 +45,7 @@ match = <rule_match-<type>>
 #
 rule_stat = %(match)s <addr_family> saddr @<addr_set> <blocktype>
 
-# optional interator over protocol's:
+# optional iterator over protocol's:
 _nft_for_proto-custom-iter =
 _nft_for_proto-custom-done =
 _nft_for_proto-allports-iter =
@@ -56,7 +56,7 @@ _nft_for_proto-multiport-done = done
 _nft_list = <nftables> -a list chain <table_family> <table> <chain>
 _nft_get_handle_id = grep -oP '@<addr_set>\s+.*\s+\Khandle\s+(\d+)$'
 
-_nft_add_set = <nftables> add set <table_family> <table> <addr_set> \{ type <addr_type>\; \}
+_nft_add_set = <nftables> add set <table_family> <table> <addr_set> \{ type <addr_type>\;<addr_options> \}
               <_nft_for_proto-<type>-iter>
               <nftables> add rule <table_family> <table> <chain> %(rule_stat)s
               <_nft_for_proto-<type>-done>
@@ -98,7 +98,7 @@ actionstop = %(_nft_del_set)s
              <_nft_shutdown_table>
 
 # Option:  actioncheck
-# Notes.:  command executed once before each actionban command
+# Notes.:  command executed once in error case by other command (during the check/restore sane environment process)
 # Values:  CMD
 #
 actioncheck = <nftables> list chain <table_family> <table> <chain> | grep -q '@<addr_set>[ \t]'
@@ -197,6 +197,11 @@ addr_set = addr-set-<name>
 # Notes.: The family of the banned addresses
 # Values: [ ip | ip6 ]
 addr_family = ip
+
+# Option: addr_options
+# Notes: Additional options for the addr-set, by default allows to store CIDR or address ranges.
+#        Can be set to empty value to create simple addresses set.
+addr_options = <sp>flags interval\;
 
 [Init?family=inet6]
 addr_family = ip6

--- a/action.d/pf.conf
+++ b/action.d/pf.conf
@@ -1,10 +1,11 @@
-## Version 2022/08/06
+## Version 2023/12/10
 # Fail2Ban configuration file
 #
 # OpenBSD pf ban/unban
 #
 # Author: Nick Hilliard <nick@foobar.org>
 # Modified by: Alexander Koeppe making PF work seamless and with IPv4 and IPv6
+# Modified by: Balazs Mateffy adding allproto option so all traffic gets blocked from the malicious source
 #
 #
 
@@ -27,9 +28,11 @@
 #     }
 # to your main pf ruleset, where "namei" are the names of the jails
 # which invoke this action
+# to block all protocols use the pf[protocol=all] option
 actionstart = echo "table <<tablename>-<name>> persist counters" | <pfctl> -f-
               port="<port>"; if [ "$port" != "" ] && case "$port" in \{*) false;; esac; then port="{$port}"; fi
-              echo "<block> proto <protocol> from <<tablename>-<name>> to <actiontype>" | <pfctl> -f-
+              protocol="<protocol>"; if [ "$protocol" != "all" ]; then protocol="proto $protocol"; else protocol=all; fi
+              echo "<block> $protocol from <<tablename>-<name>> to <actiontype>" | <pfctl> -f-
 
 # Option:  start_on_demand - to start action on demand
 # Example: `action=pf[actionstart_on_demand=true]`
@@ -99,6 +102,7 @@ tablename = f2b
 #
 # The action you want pf to take.
 # Probably, you want "block quick", but adjust as needed.
+# If you want to log all blocked use "blog log quick"
 block = block quick
 
 # Option:  protocol

--- a/action.d/shorewall-ipset-proto6.conf
+++ b/action.d/shorewall-ipset-proto6.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/06/09
 # Fail2Ban configuration file
 #
 # Author: Eduardo Diaz
@@ -52,7 +52,7 @@
 # Values:  CMD
 #
 actionstart = if ! ipset -quiet -name list f2b-<name> >/dev/null;
-              then ipset -quiet -exist create f2b-<name> hash:ip timeout <default-ipsettime>;
+              then ipset -quiet -exist create f2b-<name> <ipsettype> timeout <default-ipsettime> maxelem <maxelem>;
               fi
 
 # Option:  actionstop
@@ -89,6 +89,19 @@ default-ipsettime = 0
 # Values:  [ NUM ]  Default: 0 (managed by fail2ban by unban)
 ipsettime = 0
 
-# expresion to caclulate timeout from bantime, example:
+# expression to calculate timeout from bantime, example:
 # banaction = %(known/banaction)s[ipsettime='<timeout-bantime>']
 timeout-bantime = $([ "<bantime>" -le 2147483 ] && echo "<bantime>" || echo 0)
+
+[Init]
+
+# Option: ipsettype
+# Notes:  specifies type of set, see `man --pager='less -p "^SET TYPES"' ipset` for details
+# Values: hash:ip, hash:net, etc... Default: hash:ip
+ipsettype = hash:ip
+
+# Option: maxelem
+# Notes:  maximal number of elements which can be stored in the ipset
+#         You may want to increase this for long-duration/high-volume jails
+# Values: [ NUM ] Default: 65536
+maxelem = 65536

--- a/action.d/ufw.conf
+++ b/action.d/ufw.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2025/03/01
 # Fail2Ban action configuration file for ufw
 #
 # You are required to run "ufw enable" before this will have any effect.
@@ -45,7 +45,7 @@ _kill_conntrack = conntrack -D -s "<ip>"
 
 # Option: kill
 # Notes.: can be used to specify custom killing feature, by default depending on option kill-mode
-# Examples: banaction = ufw[kill='ss -K "( sport = :http || sport = :https )" dst "[<ip>]"']
+# Examples: banaction = ufw[kill='ss -K "dst = [<ip>] && ( sport = :http || sport = :https )"']
 #           banaction = ufw[kill='cutter "<ip>"']
 kill = <_kill_<kill-mode>>
 

--- a/filter.d/apache-auth.conf
+++ b/filter.d/apache-auth.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2023/11/18
 # Fail2Ban apache-auth filter
 #
 
@@ -65,7 +65,7 @@ ignoreregex =
 #     ^user .*: one-time-nonce mismatch - sending new nonce\s*$
 #     ^realm mismatch - got `(?:[^']*|.*?)' but no realm specified\s*$
 #
-# Because url/referer are foreign input, short form of regex used if long enough to idetify failure.
+# Because url/referer are foreign input, short form of regex used if long enough to identify failure.
 # 
 # Author: Cyril Jaquier
 # Major edits by Daniel Black and Ben Rubson.

--- a/filter.d/apache-common.conf
+++ b/filter.d/apache-common.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/03/15
 # Generic configuration items (to be used as interpolations) in other
 # apache filters.
 
@@ -30,7 +30,7 @@ apache-prefix = <apache-prefix-<logging>>
 
 apache-pref-ignore =
 
-_apache_error_client = <apache-prefix>\[(:?error|<apache-pref-ignore>\S+:\S+)\]( \[pid \d+(:\S+ \d+)?\])? \[client <HOST>(:\d{1,5})?\]
+_apache_error_client = <apache-prefix>\[(:?error|<apache-pref-ignore>\S+:\S+)\]( \[pid \d+(:\S+ \d+)?\])? \[(?:client|remote) <HOST>(:\d{1,5})?\]
 
 datepattern = {^LN-BEG}
 

--- a/filter.d/apache-noscript.conf
+++ b/filter.d/apache-noscript.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2025/03/28
 # Fail2Ban filter to block web requests for scripts (on non scripted websites)
 #
 # This matches many types of scripts that don't exist. This could generate a
@@ -20,11 +20,10 @@ before = apache-common.conf
 
 script = /\S*(?:php(?:[45]|[.-]cgi)?|\.asp|\.exe|\.pl|\bcgi-bin/)
 
-prefregex = ^%(_apache_error_client)s (?:AH0(?:01(?:28|30)|1(?:264|071)|2811): )?(?:(?:[Ff]ile|script|[Gg]ot) )<F-CONTENT>.+</F-CONTENT>$
+prefregex = ^%(_apache_error_client)s (?:AH0(?:01(?:28|30)|1(?:264|071)|2811): )?(?=(?:[Ff]ile|[Ss]cript|[Gg]ot error|stderr from) )<F-CONTENT>.+</F-CONTENT>$
 
-failregex = ^(?:does not exist|not found or unable to stat): <script>\b
-            ^'<script>\S*' not found or unable to stat
-            ^error '[Pp]rimary script unknown(?:\\n)?'
+failregex = ^(?:(?:[Ff]ile does not exist|[Ss]cript not found or unable to stat): <script>\b|[Gg]ot error '[Pp]rimary script unknown\b)
+            ^(?:stderr from |script (?P<_q>'))<script>\S*(?(_q)'|) (?:script )?(?:does not exist|not found or unable to stat)
 
 ignoreregex = 
 

--- a/filter.d/apache-overflows.conf
+++ b/filter.d/apache-overflows.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/06/28
 # Fail2Ban filter to block web requests on a long or suspicious nature
 #
 
@@ -9,7 +9,7 @@ before = apache-common.conf
 
 [Definition]
 
-failregex = ^%(_apache_error_client)s (?:(?:AH001[23][456]: )?Invalid (method|URI) in request\b|(?:AH00565: )?request failed: URI too long \(longer than \d+\)|request failed: erroneous characters after protocol string:|(?:AH00566: )?request failed: invalid characters in URI\b)
+failregex = ^%(_apache_error_client)s (?:(?:AH(?:001[23][456]|10244): )?[Ii]nvalid (method|URI)\b|(?:AH00565: )?request failed: URI too long \(longer than \d+\)|request failed: erroneous characters after protocol string:|(?:AH00566: )?request failed: invalid characters in URI\b)
 
 ignoreregex =
 

--- a/filter.d/asterisk.conf
+++ b/filter.d/asterisk.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2025/07/20
 # Fail2Ban filter for asterisk authentication failures
 #
 
@@ -22,13 +22,13 @@ log_prefix= (?:NOTICE|SECURITY|WARNING)%(__pid_re)s:?(?:\[C-[\da-f]*\])?:? [^:]+
 prefregex = ^%(__prefix_line)s%(log_prefix)s <F-CONTENT>.+</F-CONTENT>$
 
 failregex = ^Registration from '[^']*' failed for '<HOST>(:\d+)?' - (?:Wrong password|Username/auth name mismatch|No matching peer found|Not a local domain|Device does not match ACL|Peer is not supposed to register|ACL error \(permit/deny\)|Not a local domain)$
-            ^Call from '[^']*' \((?:(?:TCP|UDP):)?<HOST>:\d+\) to extension '[^']*' rejected because extension not found in context
+            ^Call (?:from '[^']*' )?\((?:(?:TCP|UDP):)?<HOST>:\d+\) to extension '[^']*' rejected because extension not found in context
             ^(?:Host )?<HOST> (?:failed (?:to authenticate\b|MD5 authentication\b)|tried to authenticate with nonexistent user\b)
             ^No registration for peer '[^']*' \(from <HOST>\)$
             ^hacking attempt detected '<HOST>'$
             ^SecurityEvent="(?:FailedACL|InvalidAccountID|ChallengeResponseFailed|InvalidPassword)"(?:(?:,(?!RemoteAddress=)\w+="[^"]*")*|.*?),RemoteAddress="IPV[46]/[^/"]+/<HOST>/\d+"(?:,(?!RemoteAddress=)\w+="[^"]*")*$
             ^"Rejecting unknown SIP connection from <HOST>(?::\d+)?"$
-            ^Request (?:'[^']*' )?from '(?:[^']*|.*?)' failed for '<HOST>(?::\d+)?'\s\(callid: [^\)]*\) - (?:No matching endpoint found|Not match Endpoint(?: Contact)? ACL|(?:Failed|Error) to authenticate)\s*$
+            ^Request (?:'[^']*' )?from '(?:[^']*|.*?)' failed for '<HOST>(?::\d+)?'\s\(callid: [^\)]*\) - (?:No matching endpoint found|Not match Endpoint(?: Contact)? ACL|(?:Failed|Error) to authenticate)\b[^']*$
 
 # FreePBX (todo: make optional in v.0.10):
 #            ^(%(__prefix_line)s|\[\]\s*WARNING%(__pid_re)s:?(?:\[C-[\da-f]*\])? )[^:]+: Friendly Scanner from <HOST>$

--- a/filter.d/dante.conf
+++ b/filter.d/dante.conf
@@ -1,4 +1,4 @@
-## Version 2022/12/15
+## Version 2023/12/30
 # Fail2Ban filter for dante
 #
 # Make sure you have "log: error" set in your "client pass" directive
@@ -10,7 +10,7 @@ before = common.conf
 [Definition]
 _daemon = danted
 
-failregex = ^%(__prefix_line)sinfo: block\(1\): tcp/accept \]: <HOST>\.\d+ [\d.]+: error after reading \d+ bytes? in \d+ seconds?: (?:could not access |system password authentication failed for )user "<F-USER>[^"]+</F-USER>"
+failregex = ^%(__prefix_line)sinfo: block\(\d\): tcp/accept \]: <ADDR>\.\d+ \S+: error after reading \d+ bytes? in \d+ seconds?: (?:could not access|system password authentication failed for|pam_authenticate\(\) for) user "<F-USER>[^"]+</F-USER>"
 
 [Init]
 journalmatch = _SYSTEMD_UNIT=danted.service

--- a/filter.d/dovecot.conf
+++ b/filter.d/dovecot.conf
@@ -1,4 +1,4 @@
-## Version 2022/12/15
+## Version 2025/08/23
 # Fail2Ban filter Dovecot authentication and pop3/imap server
 #
 
@@ -17,12 +17,12 @@ _bypass_reject_reason = (?:: (?:\w+\([^\):]*\) \w+|[^\(]+))*
 prefregex = ^%(__prefix_line)s(?:%(_auth_worker)s(?:\([^\)]+\))?: )?(?:%(__pam_auth)s(?:\(dovecot:auth\))?: |(?:pop3|imap|managesieve|submission)-login: )?(?:Info: )?%(_auth_worker_info)s<F-CONTENT>.+</F-CONTENT>$
 
 failregex = ^authentication failure; logname=<F-ALT_USER1>\S*</F-ALT_USER1> uid=\S* euid=\S* tty=dovecot ruser=<F-USER>\S*</F-USER> rhost=<HOST>(?:\s+user=<F-ALT_USER>\S*</F-ALT_USER>)?\s*$
-            ^(?:Aborted login|Disconnected|Remote closed connection|Client has quit the connection)%(_bypass_reject_reason)s \((?:auth failed, \d+ attempts(?: in \d+ secs)?|tried to use (?:disabled|disallowed) \S+ auth|proxy dest auth failed)\):(?: user=<<F-USER>[^>]*</F-USER>>,)?(?: method=\S+,)? rip=<HOST>(?:[^>]*(?:, session=<\S+>)?)\s*$
+            ^(?:Login aborted|Aborted login|Disconnected|Remote closed connection|Client has quit the connection)%(_bypass_reject_reason)s \((?:auth failed, \d+ attempts(?: in \d+ secs)?|tried to use (?:disabled|disallowed) \S+ auth|proxy dest auth failed)\)[^:]*:(?: user=<<F-USER>[^>]*</F-USER>>,)?(?: method=\S+,)? rip=<HOST>(?:[^>]*(?:, session=<\S+>)?)\s*$
             ^pam\(\S+,<HOST>(?:,\S*)?\): pam_authenticate\(\) failed: (?:User not known to the underlying authentication module: \d+ Time\(s\)|Authentication failure \([Pp]assword mismatch\?\)|Permission denied)\s*$
             ^[a-z\-]{3,15}\(\S*,<HOST>(?:,\S*)?\): (?:[Uu]nknown user|[Ii]nvalid credentials|[Pp]assword mismatch)
             <mdre-<mode>>
 
-mdre-aggressive = ^(?:Aborted login|Disconnected|Remote closed connection|Client has quit the connection)%(_bypass_reject_reason)s \((?:no auth attempts|disconnected before auth was ready,|client didn't finish \S+ auth,)(?: (?:in|waited) \d+ secs)?\):(?: user=<[^>]*>,)?(?: method=\S+,)? rip=<HOST>(?:[^>]*(?:, session=<\S+>)?)\s*$
+mdre-aggressive = ^(?:Login aborted|Aborted login|Disconnected|Remote closed connection|Client has quit the connection)%(_bypass_reject_reason)s \((?:no auth attempts|disconnected before auth was ready,|client didn't finish \S+ auth,|disconnected during TLS handshake)(?: (?:in|waited) \d+ secs)?\)[^:]*:(?: user=<[^>]*>,)?(?: method=\S+,)? rip=<HOST>(?:[^>]*(?:, session=<\S+>)?)\s*$
 
 mdre-normal = 
 
@@ -44,6 +44,7 @@ datepattern = {^LN-BEG}TAI64N
 # DEV Notes:
 # * the first regex is essentially a copy of pam-generic.conf
 # * Probably doesn't do dovecot sql/ldap backends properly (resolved in edit 21/03/2016)
+# * Dovecot version 2.4 changed event log structure, line prior needed to maintain 2.3 support
 #
 # Author: Martin Waschbuesch
 #         Daniel Black (rewrote with begin and end anchors)

--- a/filter.d/dropbear.conf
+++ b/filter.d/dropbear.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/12/27
 # Fail2Ban filter for dropbear
 #
 # NOTE: The regex below is ONLY intended to work with a patched
@@ -24,13 +24,16 @@ before = common.conf
 
 _daemon = dropbear
 
-prefregex = ^%(__prefix_line)s<F-CONTENT>(?:[Ll]ogin|[Bb]ad|[Ee]xit).+</F-CONTENT>$
+prefregex = ^%(__prefix_line)s(?:\[\d+\] \w{2,3} [\d:\s]+)?<F-CONTENT>(?:[Ll]ogin|[Bb]ad|[Ee]xit).+</F-CONTENT>$
 
-failregex = ^[Ll]ogin attempt for nonexistent user ('.*' )?from <HOST>:\d+$
-            ^[Bb]ad (PAM )?password attempt for .+ from <HOST>(:\d+)?$
-            ^[Ee]xit before auth \(user '.+', \d+ fails\): Max auth tries reached - user '.+' from <HOST>:\d+\s*$
+failregex = ^[Ll]ogin attempt for nonexistent user (?:'<F-USER>.*</F-USER>' )?from <HOST>:\d+$
+            ^[Bb]ad (?:PAM )?password attempt for '<F-USER>.+</F-USER>' from <HOST>(?::\d+)?$
+            ^[Ee]xit before auth from \<?<ADDR>:\d+\>?: (?:\([^\)]*\): )?Max auth tries reached - user '<F-USER>.+</F-USER>'\s*$
+            ^[Ee]xit before auth \(user '.+', \d+ fails\): Max auth tries reached - user '<F-USER>.+</F-USER>' from <HOST>:\d+\s*$
 
 ignoreregex = 
+
+journalmatch = _SYSTEMD_UNIT=dropbear.service + _COMM=dropbear
 
 # DEV Notes:
 #

--- a/filter.d/exim-common.conf
+++ b/filter.d/exim-common.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/03/25
 # Fail2Ban filter file for common exim expressions
 #
 # This is to be used by other exim filters
@@ -10,12 +10,43 @@ after = exim-common.local
 
 [Definition]
 
-host_info_pre = (?:H=([\w.-]+ )?(?:\(\S+\) )?)?
-host_info_suf = (?::\d+)?(?: I=\[\S+\](:\d+)?)?(?: U=\S+)?(?: P=e?smtp)?(?: F=(?:<>|[^@]+@\S+))?\s
-host_info = %(host_info_pre)s\[<HOST>\]%(host_info_suf)s
-pid = (?: \[\d+\]| \w+ exim\[\d+\]:)?
+_fields_grp = (?: (?!H=)[A-Za-z]{1,4}(?:=\S+)?)*
+host_info = %(_fields_grp)s (?:H=)?(?:[\w.-]+)? ?(?:\(\S+\))? ?\[<ADDR>\](?::\d+)?%(_fields_grp)s
+pid = (?:\s?\[\d+\]|\s?[\w\.-]+ exim\[\d+\]:){0,2}
 
-# DEV Notes:
-# From exim source code: ./src/receive.c:add_host_info_for_log
-#
-# Author:  Daniel Black
+logtype = file
+_add_pref = <lt_<logtype>/_add_pref>
+
+__prefix_line = %(pid)s%(_add_pref)s
+
+[lt_journal]
+_add_pref = (?: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})?
+
+[lt_file]
+_add_pref =
+
+# DEV Notes
+# ------------
+# Host string happens:
+# H=[ip address]
+# H=(helo_name) [ip address]
+# H=host_name [ip address]
+# H=host_name (helo_name) [ip address]
+# flags H=host_name (helo_name) [ip address] flags
+# where only [ip address] always visible, ignore ident
+# From exim source code:
+#   src/src/host.c:host_and_ident()
+#   src/receive.c:add_host_info_for_log()
+
+# Substitution of `_fields_grp` bypasses all flags but H
+# Summary of Fields in Log Lines depending on log_selector
+# https://www.exim.org/exim-html-current/doc/html/spec_html/ch-log_files.html
+# at version exim-4.97.1
+# ---
+
+# Authors:
+#   Cyril Jaquier
+#   Daniel Black (rewrote with strong regexs)
+#   Sergey G. Brester aka sebres (optimization, rewrite to prefregex, reviews)
+#   Martin O'Neal (added additional regexs to detect authentication failures, protocol errors, and drops)
+#   Vladimir Varlamov (host line definition)

--- a/filter.d/exim-spam.conf
+++ b/filter.d/exim-spam.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/03/25
 # Fail2Ban filter for exim the spam rejection messages
 #
 # Honeypot traps are very useful for fighting spam. You just activate an email
@@ -27,11 +27,13 @@ before = exim-common.conf
 
 [Definition]
 
-failregex =  ^%(pid)s \S+ F=(<>|\S+@\S+) %(host_info)srejected by local_scan\(\): .{0,256}$
-             ^%(pid)s %(host_info)sF=(<>|[^@]+@\S+) rejected RCPT [^@]+@\S+: .*dnsbl.*\s*$
-             ^%(pid)s \S+ %(host_info)sF=(<>|[^@]+@\S+) rejected after DATA: This message contains a virus \(\S+\)\.\s*$
-             ^%(pid)s \S+ SA: Action: flagged as Spam but accepted: score=\d+\.\d+ required=\d+\.\d+ \(scanned in \d+/\d+ secs \| Message-Id: \S+\)\. From \S+ \(host=\S+ \[<HOST>\]\) for <honeypot>$
-             ^%(pid)s \S+ SA: Action: silently tossed message: score=\d+\.\d+ required=\d+\.\d+ trigger=\d+\.\d+ \(scanned in \d+/\d+ secs \| Message-Id: \S+\)\. From \S+ \(host=(\S+ )?\[<HOST>\]\) for \S+$
+prefregex = ^%(__prefix_line)s<F-CONTENT>.+</F-CONTENT>$
+
+failregex =  ^\s?\S+%(host_info)s rejected by local_scan\(\): .{0,256}$
+             ^%(host_info)s rejected RCPT [^@]+@\S+: .*dnsbl.*\s*$
+             ^\s?\S+%(host_info)s rejected after DATA: This message contains a virus \(\S+\)\.\s*$
+             ^\s?\S+ SA: Action: flagged as Spam but accepted: score=\d+\.\d+ required=\d+\.\d+ \(scanned in \d+/\d+ secs \| Message-Id: \S+\)\. From \S+ \(host=\S+ \[<HOST>\]\) for <honeypot>$
+             ^\s?\S+ SA: Action: silently tossed message: score=\d+\.\d+ required=\d+\.\d+ trigger=\d+\.\d+ \(scanned in \d+/\d+ secs \| Message-Id: \S+\)\. From \S+ \(host=(\S+ )?\[<HOST>\]\) for \S+$
 
 ignoreregex = 
 
@@ -44,8 +46,6 @@ ignoreregex =
 
 honeypot = trap@example.com
 
-# DEV Notes:
-# The %(host_info) defination contains a <HOST> match
-#
-# Author: Cyril Jaquier
-#         Daniel Black (rewrote with strong regexs)
+# DEV Notes
+# -----------
+# The %(host_info) definition contains a <ADDR> match. No space before. See exim-common.conf

--- a/filter.d/exim.conf
+++ b/filter.d/exim.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2025/04/27
 # Fail2Ban filter for exim
 #
 # This includes the rejection messages of exim. For spam and filter
@@ -14,21 +14,23 @@ before = exim-common.conf
 
 [Definition]
 
-# Fre-filter via "prefregex" is currently inactive because of too different failure syntax in exim-log (testing needed):
-#prefregex = ^%(pid)s <F-CONTENT>\b(?:\w+ authenticator failed|([\w\-]+ )?SMTP (?:(?:call|connection) from|protocol(?: synchronization)? error)|no MAIL in|(?:%(host_info_pre)s\[[^\]]+\]%(host_info_suf)s(?:sender verify fail|rejected RCPT|dropped|AUTH command))).+</F-CONTENT>$
+prefregex = ^%(__prefix_line)s<F-CONTENT>.+</F-CONTENT>$
 
-failregex = ^%(pid)s %(host_info)ssender verify fail for <\S+>: (?:Unknown user|Unrouteable address|all relevant MX records point to non-existent hosts)\s*$
-            ^%(pid)s \w+ authenticator failed for (?:[^\[\( ]* )?(?:\(\S*\) )?\[<HOST>\](?::\d+)?(?: I=\[\S+\](:\d+)?)?: 535 Incorrect authentication data( \(set_id=.*\)|: \d+ Time\(s\))?\s*$
-            ^%(pid)s %(host_info)srejected RCPT [^@]+@\S+: (?:relay not permitted|Sender verify failed|Unknown user|Unrouteable address)\s*$
-            ^%(pid)s SMTP protocol synchronization error \([^)]*\): rejected (?:connection from|"\S+") %(host_info)s(?:next )?input=".*"\s*$
-            ^%(pid)s SMTP call from (?:[^\[\( ]* )?%(host_info)sdropped: too many (?:nonmail commands|syntax or protocol errors) \(last (?:command )?was "[^"]*"\)\s*$
-            ^%(pid)s SMTP protocol error in "[^"]+(?:"+[^"]*(?="))*?" %(host_info)sAUTH command used when not advertised\s*$
-            ^%(pid)s no MAIL in SMTP connection from (?:[^\[\( ]* )?(?:\(\S*\) )?%(host_info)sD=\d\S*s(?: C=\S*)?\s*$
-            ^%(pid)s (?:[\w\-]+ )?SMTP connection from (?:[^\[\( ]* )?(?:\(\S*\) )?%(host_info)sclosed by DROP in ACL\s*$
+failregex = ^\s?\w+ authenticator failed for%(host_info)s: 535 Incorrect authentication data(?: \(set_id=.*\)|: \d+ Time\(s\))?\s*$
             <mdre-<mode>>
 
-mdre-aggressive = ^%(pid)s no host name found for IP address <HOST>$
-                  ^%(pid)s no IP address found for host \S+ \(during SMTP connection from \[<HOST>\]\)$
+mdre-more = ^%(host_info)s sender verify fail for <\S+>: (?:Unknown user|Unrouteable address|all relevant MX records point to non-existent hosts)\s*$
+            ^%(host_info)s rejected RCPT (?:<F-RCPT>[^@]+@\S+</F-RCPT>:)?
+            ^\s?SMTP protocol synchronization error \([^)]*\): rejected (?:connection from|"\S+")%(host_info)s (?:next )?input=".*"\s*$
+            ^\s?SMTP call from%(host_info)s dropped: too many (?:(?:nonmail|unrecognized) commands|syntax or protocol errors)
+            ^\s?SMTP protocol error in "[^"]+(?:"+[^"]*(?="))*?"%(host_info)s [A-Z]+ (?:command used when not advertised|authentication mechanism not supported)\s*$
+            ^\s?no MAIL in SMTP connection from%(host_info)s
+            ^\s?(?:[\w\-]+ )?SMTP connection from%(host_info)s closed by DROP in ACL\s*$
+
+mdre-aggressive = %(mdre-more)s
+                  ^\s?no host name found for IP address <ADDR>$
+                  ^\s?no IP address found for host \S+ \(during SMTP connection from%(host_info)s\)$
+                  ^%(host_info)s dropped by '[^']+' ACL:
 
 mdre-normal = 
 
@@ -43,13 +45,10 @@ mode = normal
 
 ignoreregex = 
 
-# DEV Notes:
-# The %(host_info) defination contains a <HOST> match
+# DEV Notes
+# -----------
+# The %(host_info) definition contains a <ADDR> match. No space before. See exim-common.conf
 #
 # SMTP protocol synchronization error \([^)]*\)  <- This needs to be non-greedy
-# to void capture beyond ")" to avoid a DoS Injection vulnerabilty as input= is
+# to void capture beyond ")" to avoid a DoS Injection vulnerability as input= is
 # user injectable data.
-#
-# Author: Cyril Jaquier
-#         Daniel Black (rewrote with strong regexs)
-#         Martin O'Neal (added additional regexs to detect authentication failures, protocol errors, and drops)

--- a/filter.d/freeswitch.conf
+++ b/filter.d/freeswitch.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/12/04
 # Fail2Ban configuration file
 #
 # Enable "log-auth-failures" on each Sofia profile to monitor
@@ -30,9 +30,9 @@ _daemon = freeswitch
 mode = extra
               
 # Prefix contains common prefix line (server, daemon, etc.) and 2 datetimes if used systemd backend
-_pref_line = ^%(__prefix_line)s(?:(?:\d+-)?\d+-\d+ \d+:\d+:\d+\.\d+)?
+_pref_line = ^%(__prefix_line)s[^\[]*
 
-prefregex = ^%(_pref_line)s \[WARN(?:ING)?\](?: \[SOFIA\])? \[?sofia_reg\.c:\d+\]? <F-CONTENT>.+</F-CONTENT>$
+prefregex = ^%(_pref_line)s\s*\[WARN(?:ING)?\](?: \[SOFIA\])? \[?sofia_reg\.c:\d+\]? <F-CONTENT>.+</F-CONTENT>$
 
 cmnfailre = ^Can't find user \[[^@]+@[^\]]+\] from <HOST>$
 

--- a/filter.d/lighttpd-auth.conf
+++ b/filter.d/lighttpd-auth.conf
@@ -1,11 +1,11 @@
-## Version 2022/08/06
+## Version 2025/03/04
 # Fail2Ban filter to match wrong passwords as notified by lighttpd's auth Module
 #
 
 [Definition]
 
-failregex = ^\s*(?:: )?\(?(?:http|mod)_auth\.c\.\d+\) (?:password doesn\'t match for (?:\S+|.*?) username:\s+<F-USER>(?:\S+|.*?)</F-USER>\s*|digest: auth failed(?: for\s+<F-ALT_USER>(?:\S+|.*?)</F-ALT_USER>\s*)?: (?:wrong password|uri mismatch \([^\)]*\))|get_password failed),? IP: <HOST>\s*$
+failregex = ^[^\)]*\(?(?:http|mod)_auth\.c\.\d+\) (?:password doesn\'t match for (?:\S+|.*?) username:\s+<F-USER>(?:\S+|.*?)</F-USER>\s*|digest: auth failed(?: for\s+<F-ALT_USER>(?:\S+|.*?)</F-ALT_USER>\s*)?: (?:wrong password|uri mismatch \([^\)]*\))|get_password failed),? IP: <HOST>\s*$
 
-ignoreregex = 
+ignoreregex =
 
-# Author: Francois Boulogne <fboulogne@april.org>
+# Authors: Francois Boulogne <fboulogne@april.org>, Lucian Maly <lmaly@redhat.com>

--- a/filter.d/mongodb-auth.conf
+++ b/filter.d/mongodb-auth.conf
@@ -1,5 +1,5 @@
-## Version 2022/08/06
-# Fail2Ban filter for unsuccesfull MongoDB authentication attempts
+## Version 2023/11/18
+# Fail2Ban filter for unsuccessful MongoDB authentication attempts
 #
 # Logfile /var/log/mongodb/mongodb.log
 #
@@ -24,7 +24,7 @@ maxlines = 10
 #
 # Regarding the multiline regex:
 #
-# There can be a nunber of non-related lines between the first and second part
+# There can be a number of non-related lines between the first and second part
 # of this regex maxlines of 10 is quite generious.
 #
 # Note the capture __connid, includes the connection ID, used in second part of regex.

--- a/filter.d/mysqld-auth.conf
+++ b/filter.d/mysqld-auth.conf
@@ -1,10 +1,11 @@
-## Version 2022/08/06
-# Fail2Ban filter for unsuccesful MySQL authentication attempts
+## Version 2025/01/30
+# Fail2Ban filter for unsuccessful MySQL authentication attempts
 #
 #
-# To log wrong MySQL access attempts add to /etc/my.cnf in [mysqld]:
-# log-error=/var/log/mysqld.log
-# log-warnings = 2
+# To log wrong MySQL access attempts add to /etc/my.cnf in [mysqld],
+# `log_error_verbosity` system variable set to 3 (`log-warnings = 2` for older versions),
+# and check whether `log_error` (or `log-error`) system variable would match the `logpath` of fail2ban
+# (see https://dev.mysql.com/doc/refman/en/communication-errors.html)
 #
 # If using mysql syslog [mysql_safe] has syslog in /etc/my.cnf
 
@@ -18,7 +19,7 @@ before = common.conf
 
 _daemon = mysqld
 
-failregex = ^%(__prefix_line)s(?:(?:\d{6}|\d{4}-\d{2}-\d{2})[ T]\s?\d{1,2}:\d{2}:\d{2} )?(?:\d+ )?\[\w+\] (?:\[[^\]]+\] )*Access denied for user '<F-USER>[^']+</F-USER>'@'<HOST>' (to database '[^']*'|\(using password: (YES|NO)\))*\s*$
+failregex = ^%(__prefix_line)s(?:(?:\d{6}|\d{4}-\d{2}-\d{2})[ T]\s?\d{1,2}:\d{2}:\d{2} )?(?:\d+ )?\[\w+\] (?:\[[^\]]+\] )*Access denied for user '<F-USER>[^']+</F-USER>'@'<HOST>'(?:\s+(?:to database '[^']*'|\(using password: (?:YES|NO)\)){1,2})?\s*$
 
 ignoreregex = 
 

--- a/filter.d/named-refused.conf
+++ b/filter.d/named-refused.conf
@@ -1,4 +1,4 @@
-## Version 2022/12/15
+## Version 2024/03/25
 # Fail2Ban filter file for named (bind9).
 #
 
@@ -38,7 +38,7 @@ _category_re = (?:%(_category)s: )?
 # this can be optional (for instance if we match named native log files)
 __line_prefix=\s*(?:\S+ %(__daemon_combs_re)s\s+)?%(_category_re)s
 
-prefregex = ^%(__line_prefix)s(?:(?:error|info):\s*)?client(?: @\S*)? <HOST>#\S+(?: \([\S.]+\))?: <F-CONTENT>.+</F-CONTENT>\s(?:denied|\(NOTAUTH\))\s*$
+prefregex = ^%(__line_prefix)s(?:(?:error|info):\s*)?client(?: @\S*)? <HOST>#\S+(?: \([\S.]+\))?: <F-CONTENT>.+</F-CONTENT>\s(?:denied(?: \([^\)]*\))?|\(NOTAUTH\))\s*$
 
 failregex = ^(?:view (?:internal|external): )?query(?: \(cache\))?
             ^zone transfer

--- a/filter.d/nginx-error-common.conf
+++ b/filter.d/nginx-error-common.conf
@@ -1,0 +1,33 @@
+## Version 2023/12/10
+# Generic nginx error_log configuration items (to be used as interpolations) in other
+# filters monitoring nginx error-logs
+#
+
+[DEFAULT]
+
+# Type of log-file resp. log-format (file, short, journal):
+logtype = file
+
+# Daemon definition is to be specialized (if needed) in .conf file
+_daemon = nginx
+
+# Common line prefixes (beginnings) which could be used in filters
+#
+#      [bsdverbose]? [hostname] [vserver tag] daemon_id spaces
+#
+# This can be optional (for instance if we match named native log files)
+__prefix = <lt_<logtype>/__prefix>
+
+__err_type = error
+
+__prefix_line = %(__prefix)s\[%(__err_type)s\] \d+#\d+: \*\d+\s+
+
+
+[lt_file]
+__prefix = \s*
+
+[lt_short]
+__prefix = \s*(?:(?!\[)\S+ %(_daemon)s\[\d+\]: [^\[]*)?
+
+[lt_journal]
+__prefix = %(lt_short/__prefix)s

--- a/filter.d/nginx-forbidden.conf
+++ b/filter.d/nginx-forbidden.conf
@@ -1,0 +1,30 @@
+## Version 2023/12/10
+# fail2ban filter configuration for nginx forbidden accesses
+#
+# If you have configured nginx to forbid some paths in your webserver, e.g.:
+#
+#       location ~ /\. {
+#         deny all;
+#       }
+#
+# if a client tries to access https://yoursite/.user.ini then you will see
+# in nginx error log:
+#
+# 2018/09/14 19:03:05 [error] 2035#2035: *9134 access forbidden by rule, client: 10.20.30.40, server: www.example.net, request: "GET /.user.ini HTTP/1.1", host: "www.example.net", referrer: "https://www.example.net"
+#
+# By carefully setting this filter we ban every IP that tries too many times to
+# access forbidden resources.
+#
+# Author: Michele Bologna https://www.michelebologna.net/
+
+[INCLUDES]
+
+before = nginx-error-common.conf
+
+[Definition]
+failregex = ^%(__prefix_line)saccess forbidden by rule, client: <HOST>
+ignoreregex =
+
+datepattern = {^LN-BEG}
+
+journalmatch = _SYSTEMD_UNIT=nginx.service + _COMM=nginx

--- a/filter.d/nginx-http-auth.conf
+++ b/filter.d/nginx-http-auth.conf
@@ -1,15 +1,24 @@
-## Version 2022/08/06
+## Version 2023/12/10
 # fail2ban filter configuration for nginx
 
+[INCLUDES]
+
+before = nginx-error-common.conf
 
 [Definition]
 
 mode = normal
 
-mdre-auth = ^\s*\[error\] \d+#\d+: \*\d+ user "(?:[^"]+|.*?)":? (?:password mismatch|was not found in "[^\"]*"), client: <HOST>, server: \S*, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"(?:, referrer: "\S+")?\s*$
-mdre-fallback = ^\s*\[crit\] \d+#\d+: \*\d+ SSL_do_handshake\(\) failed \(SSL: error:\S+(?: \S+){1,3} too (?:long|short)\)[^,]*, client: <HOST>
+__err_type = <_ertp-<mode>>
 
+_ertp-auth = error
+mdre-auth = ^%(__prefix_line)suser "(?:[^"]+|.*?)":? (?:password mismatch|was not found in "[^\"]*"), client: <HOST>, server: \S*, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"(?:, referrer: "\S+")?\s*$
+_ertp-fallback = crit
+mdre-fallback = ^%(__prefix_line)sSSL_do_handshake\(\) failed \(SSL: error:\S+(?: \S+){1,3} too (?:long|short)\)[^,]*, client: <HOST>
+
+_ertp-normal = %(_ertp-auth)s
 mdre-normal = %(mdre-auth)s
+_ertp-aggressive = (?:%(_ertp-auth)s|%(_ertp-fallback)s)
 mdre-aggressive = %(mdre-auth)s
                   %(mdre-fallback)s
 

--- a/filter.d/nginx-limit-req.conf
+++ b/filter.d/nginx-limit-req.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2025/08/04
 # Fail2ban filter configuration for nginx :: limit_req
 # used to ban hosts, that were failed through nginx by limit request processing rate 
 #
@@ -24,6 +24,10 @@
 #   ...
 #
 
+[INCLUDES]
+
+before = nginx-error-common.conf
+
 [Definition]
 
 # Specify following expression to define exact zones, if you want to ban IPs limited 
@@ -34,13 +38,16 @@
 #
 ngx_limit_req_zones = [^"]+
 
+# Depending on limit_req_log_level directive (may be: info | notice | warn | error):
+__err_type = [a-z]+
+
 # Use following full expression if you should range limit request to specified 
 # servers, requests, referrers etc. only :
 #
-# failregex = ^\s*\[[a-z]+\] \d+#\d+: \*\d+ limiting requests, excess: [\d\.]+ by zone "(?:%(ngx_limit_req_zones)s)", client: <HOST>, server: \S*, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"(, referrer: "\S+")?\s*$
+# failregex = ^%(__prefix_line)slimiting requests, excess: [\d\.]+ by zone "(?:%(ngx_limit_req_zones)s)", client: <HOST>, server: \S*, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"(, referrer: "\S+")?\s*$
 
 # Shortly, much faster and stable version of regexp:
-failregex = ^\s*\[[a-z]+\] \d+#\d+: \*\d+ limiting requests, excess: [\d\.]+ by zone "(?:%(ngx_limit_req_zones)s)", client: <HOST>,
+failregex = ^%(__prefix_line)s(?:limiting|delaying) (?:request|connection)s?(?:, excess: [\d\.]+,?)? by zone "(?:%(ngx_limit_req_zones)s)", client: <ADDR>,
 
 ignoreregex = 
 

--- a/filter.d/openvpn.conf
+++ b/filter.d/openvpn.conf
@@ -1,0 +1,14 @@
+## Version 2025/01/30
+# Fail2Ban filter for openvpn server
+# Detecting wrong TLS handshakes
+# typically logged in /var/log/syslog
+# Author: Philipp Burndorfer
+
+[INCLUDES]
+before = common.conf
+
+[Definition]
+_daemon = ovpn-server\d*
+
+failregex = ^%(__prefix_line)s<HOST>:\d{4,5} (?:TLS Auth Error:|VERIFY ERROR:|TLS Error: TLS handshake failed\b|SIGUSR1\[soft,connection-reset\] received\b)
+            ^%(__prefix_line)sTLS Error: cannot locate HMAC in incoming packet from \[AF_INET\]\s*<HOST>:\d{4,5}

--- a/filter.d/postfix.conf
+++ b/filter.d/postfix.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2025/03/10
 # Fail2Ban filter for selected Postfix SMTP rejections
 #
 #
@@ -11,17 +11,17 @@ before = common.conf
 
 [Definition]
 
-_daemon = postfix(-\w+)?/\w+(?:/smtp[ds])?
+_daemon = postfix\b([^\[\s]+)?
 _port = (?::\d+)?
-_pref = [A-Z]{4}
+_pref = [A-Z]{4,}
 
 prefregex = ^%(__prefix_line)s<mdpr-<mode>> <F-CONTENT>.+</F-CONTENT>$
 
 # Extended RE for normal mode to match reject by unknown users or undeliverable address, can be set to empty to avoid this:
-exre-user = |[Uu](?:ser unknown|ndeliverable address)
+exre-user = |[Uu](?:ser unknown|ndeliverable address)  ; pragma: codespell-ignore
 
 mdpr-normal = (?:\w+: (?:milter-)?reject:|(?:improper command pipelining|too many errors) after \S+)
-mdre-normal=^%(_pref)s from [^[]*\[<HOST>\]%(_port)s: [45][50][04] [45]\.\d\.\d+ (?:(?:<[^>]*>)?: )?(?:(?:Helo command|(?:Sender|Recipient) address) rejected: )?(?:Service unavailable|(?:Client host|Command|Data command) rejected|Relay access denied|(?:Host|Domain) not found|need fully-qualified hostname|match%(exre-user)s)\b
+mdre-normal=^%(_pref)s from [^[]*\[<HOST>\]%(_port)s: [45][50][04] [45]\.\d\.\d+ (?:(?:<[^>]*>)?: )?(?:(?:Helo command|(?:Sender|Recipient) address) rejected: )?(?:Service unavailable|Access denied|(?:Client host|Command|Data command) rejected|Relay access denied|Malformed DNS server reply|(?:Host|Domain) not found|need fully-qualified hostname|match%(exre-user)s)\b
             ^from [^[]*\[<HOST>\]%(_port)s:?
 
 mdpr-auth = warning:
@@ -39,7 +39,7 @@ mdre-more = %(mdre-normal)s
 
 # Includes some of the log messages described in
 # <http://www.postfix.org/POSTSCREEN_README.html>.
-mdpr-ddos = (?:lost connection after(?! DATA) [A-Z]+|disconnect(?= from \S+(?: \S+=\d+)* auth=0/(?:[1-9]|\d\d+))|(?:PREGREET \d+|HANGUP) after \S+|COMMAND (?:TIME|COUNT|LENGTH) LIMIT)
+mdpr-ddos = (?:lost connection after (?!(?:DATA|AUTH)\b)[A-Z]+|disconnect(?= from \S+(?: \S+=\d+)* auth=0/(?:[1-9]|\d\d+))|(?:PREGREET \d+|HANGUP) after \S+|COMMAND (?:TIME|COUNT|LENGTH) LIMIT)
 mdre-ddos = ^from [^[]*\[<HOST>\]%(_port)s:?
 
 mdpr-extra = (?:%(mdpr-auth)s|%(mdpr-normal)s)
@@ -77,6 +77,6 @@ ignoreregex =
 
 [Init]
 
-journalmatch = _SYSTEMD_UNIT=postfix.service
+journalmatch = _SYSTEMD_UNIT=postfix.service _SYSTEMD_UNIT=postfix@-.service
 
 # Author: Cyril Jaquier

--- a/filter.d/proxmox.conf
+++ b/filter.d/proxmox.conf
@@ -1,0 +1,21 @@
+## Version 2024/07/30
+# Fail2Ban filter for Proxmox Web GUI
+#
+# Jail example:
+#    [proxmox]
+#    enabled = true
+#    port = https,http,8006
+#    filter = proxmox
+#    logpath = /var/log/daemon.log
+#    maxretry = 3
+#    # 1 hour
+#    bantime = 3600
+
+[Definition]
+
+_daemon = pvedaemon
+
+failregex = ^\s*\S+ %(_daemon)s\[\d+\]: authentication failure; rhost=<ADDR> user=<F-USER>\S+</F-USER>
+
+ignoreregex =
+

--- a/filter.d/recidive.conf
+++ b/filter.d/recidive.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/06/21
 # Fail2Ban filter for repeat bans
 #
 # This filter monitors the fail2ban log file, and enables you to add long 
@@ -20,20 +20,34 @@
 # common.local
 before = common.conf
 
-[Definition]
+[DEFAULT]
 
 _daemon = (?:fail2ban(?:-server|\.actions)\s*)
 
 # The name of the jail that this filter is used for. In jail.conf, name the jail using
-# this filter 'recidive', or supply another name with `filter = recidive[_jailname="jail"]`
-_jailname = recidive
+# this filter 'recidive', or supply another name with `filter = recidive[_jailname="jail"]`,
+# default all jails excepting recidive
+_jailname = (?!recidive\])[^\]]*
 
-failregex = ^%(__prefix_line)s(?:\s*fail2ban\.actions\s*%(__pid_re)s?:\s+)?NOTICE\s+\[(?!%(_jailname)s\])(?:.*)\]\s+Ban\s+<HOST>\s*$
+failregex = ^%(__prefix_line)s(?:\s*fail2ban\.actions\s*%(__pid_re)s?:\s+)?NOTICE\s+\[<_jailname>\]\s+Ban\s+<HOST>
+
+[lt_short]
+_daemon = (?:fail2ban(?:-server|\.actions)?\s*)
+failregex = ^%(__prefix_line)s(?:\s*fail2ban(?:\.actions)?\s*%(__pid_re)s?:\s+)?(?:NOTICE\s+)?\[<_jailname>\]\s+Ban\s+<HOST>
+
+[lt_journal]
+_daemon = <lt_short/_daemon>
+failregex = <lt_short/failregex>
+
+[Definition]
+
+_daemon = <lt_<logtype>/_daemon>
+failregex = <lt_<logtype>/failregex>
 
 datepattern = ^{DATE}
 
 ignoreregex = 
 
-journalmatch = _SYSTEMD_UNIT=fail2ban.service PRIORITY=5
+journalmatch = _SYSTEMD_UNIT=fail2ban.service
 
 # Author: Tom Hendrikx, modifications by Amir Caspi 

--- a/filter.d/roundcube-auth.conf
+++ b/filter.d/roundcube-auth.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/08/10
 # Fail2Ban configuration file for roundcube web server
 #
 # By default failed logins are printed to 'errors'. The first regex matches those
@@ -14,10 +14,9 @@ before = common.conf
 
 [Definition]
 
-prefregex = ^\s*(\[\])?(%(__hostname)s\s*(?:roundcube(?:\[(\d*)\])?:)?\s*(<[\w]+>)? IMAP Error)?: <F-CONTENT>.+</F-CONTENT>$
+prefregex = ^\s*(\[\])?(%(__hostname)s\s*(?:roundcube(?:\[(\d*)\])?:)?\s*(<[\w]+>)? IMAP Error)?: (?:<[\w]+> )?<F-CONTENT>.+</F-CONTENT>$
 
-failregex = ^(?:FAILED login|Login failed) for <F-USER>.*</F-USER> from <HOST>(?:(?:\([^\)]*\))?\. (?:(?! from ).)*(?: user=(?P=user))? in \S+\.php on line \d+ \(\S+ \S+\))?$
-            ^(?:<[\w]+> )?Failed login for <F-USER>.*</F-USER> from <HOST> in session \w+( \(error: \d\))?$
+failregex = ^(?:Login failed|(?i:Failed) login) for <F-USER>(?:(?P<simple>\S+)|.*)</F-USER> (?:against \S+ )?from <ADDR>(?:(?:\([^\)]*\))?\.(?! from ) (?(simple)(?:\S+(?! from ) )*|(?:(?! from ).)*(?: user=(?P=user))? )in \S+\.php on line \d+| in session \w+)?(?: \([^\)]*\))?$
 
 ignoreregex = 
 

--- a/filter.d/routeros-auth.conf
+++ b/filter.d/routeros-auth.conf
@@ -1,0 +1,11 @@
+## Version 2023/03/02
+# Fail2Ban filter for failure attempts in MikroTik RouterOS
+#
+#
+
+[Definition]
+
+failregex = ^\s*\S+ system,error,critical login failure for user <F-USER>.*?</F-USER> from <ADDR> via \S+$
+
+# Author: Vit Kabele <vit@kabele.me>
+

--- a/filter.d/selinux-ssh.conf
+++ b/filter.d/selinux-ssh.conf
@@ -1,4 +1,4 @@
-## Version 2022/12/15
+## Version 2023/11/18
 # Fail2Ban configuration file for SELinux ssh authentication errors
 #
 
@@ -22,7 +22,7 @@ _msg = (?:%(_anygrp)s )*acct=(?:"<F-USER>[^"]+</F-USER>"|<F-ALT_USER>\S+</F-ALT_
 
 # DEV Notes:
 #
-# Note: USER_LOGIN is ignored as this is the duplicate messsage
+# Note: USER_LOGIN is ignored as this is the duplicate message
 # ssh logs after 3 USER_AUTH failures.
 #
 # Author: Daniel Black

--- a/filter.d/sendmail-reject.conf
+++ b/filter.d/sendmail-reject.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2025/09/02
 # Fail2Ban filter for sendmail spam/relay type failures
 #
 # Some of the below failregex will only work properly, when the following
@@ -23,21 +23,28 @@ before = common.conf
 _daemon = (?:(sm-(mta|acceptingconnections)|sendmail))
 __prefix_line = %(known/__prefix_line)s(?:\w{14,20}: )?
 addr = (?:(?:IPv6:)?<IP6>|<IP4>)
+# mta_dname -- matches name of MTA daemon (typically specified in DAEMON_OPTIONS),
+# normally something without spaces like MTA-v4 or Deamon0, etc. If it'd contain spaces, one can
+# rewrite it in jail using  `filter = %(known/filter)s[mta_dname="[^,]+"]` or in .local overwrite
+# of the filter. (we would not use catch-alls here to satisfy obscure artificial case).
+mta_dname = \S+
 
-prefregex = ^<F-MLFID>%(__prefix_line)s</F-MLFID><F-CONTENT>.+</F-CONTENT>$
+prefregex = ^\s*(?:<mail\.[^\>]+> )?<F-MLFID>%(__prefix_line)s</F-MLFID><F-CONTENT>.+</F-CONTENT>$
 
-cmnfailre = ^ruleset=check_rcpt, arg1=(?P<email><\S+@\S+>), relay=(\S+ )?\[%(addr)s\](?: \(may be forged\))?, reject=(?:550 5\.7\.1(?: (?P=email)\.\.\.)?(?: Relaying denied\.)? (?:IP name possibly forged \[(\d+\.){3}\d+\]|Proper authentication required\.|IP name lookup failed \[(\d+\.){3}\d+\]|Fix reverse DNS for \S+)|553 5\.1\.8(?: (?P=email)\.\.\.)? Domain of sender address \S+ does not exist|550 5\.[71]\.1 (?P=email)\.\.\. (Rejected: .*|User unknown))$
+cmnfailre = ^ruleset=check_rcpt, arg1=(?P<email><\S+@\S+>), relay=(\S+ )?\[%(addr)s\](?: \(may be forged\))?, reject=(?:550 5\.7\.1(?: (?P=email)\.\.\.)?(?: Relaying denied\.)? (?:IP name possibly forged \[(\d+\.){3}\d+\]|Proper authentication required\.|IP name lookup failed \[(\d+\.){3}\d+\]|Fix reverse DNS for \S+)|[45]5[13] [45]\.1\.8(?: (?P=email)\.\.\.)? Domain of sender address \S+ does not (?:exist|resolve)|550 5\.[71]\.1 (?P=email)\.\.\. (Rejected: .*|User unknown))$
             ^ruleset=check_relay(?:, arg\d+=\S*)*, relay=(\S+ )?\[%(addr)s\](?: \(may be forged\))?, reject=421 4\.3\.2 (Connection rate limit exceeded\.|Too many open connections\.)$
             ^rejecting commands from (\S* )?\[%(addr)s\] due to pre-greeting traffic after \d+ seconds$
             ^(?:\S+ )?\[%(addr)s\]: (?:(?i)expn|vrfy) \S+ \[rejected\]$
-            ^<[^@]+@[^>]+>\.\.\. No such user here$
-            ^<F-NOFAIL>from=<[^@]+@[^>]+></F-NOFAIL>, size=\d+, class=\d+, nrcpts=\d+, bodytype=\w+, proto=E?SMTP, daemon=MTA, relay=\S+ \[%(addr)s\]$
+            ^<[^@]+@[^>]+>\.\.\. (?:No such user here|User unknown)$
+            ^<F-NOFAIL>from=<[^@]+@[^>]+></F-NOFAIL>, size=\d+, class=\d+, nrcpts=\d+,(?: bodytype=\w+,)? proto=E?SMTP, daemon=%(mta_dname)s, relay=(?:\S+ )?\[%(addr)s\]$
 
 mdre-normal =
 
 mdre-extra = ^(?:\S+ )?\[%(addr)s\](?: \(may be forged\))? did not issue \S+ during connection
 
 mdre-aggressive = %(mdre-extra)s
+                  ^lost input channel from (?:\S+ )?\[%(addr)s\] to %(mta_dname)s after rcpt$
+                  ^ruleset=check_rcpt, arg1=(?P<email><\S+@\S+>), relay=(?:\S+ )?\[%(addr)s\](?: \(may be forged\))?, reject=(?:450 4\.4\.0(?: (?P=email)\.\.\.)?(?: Relaying temporarily denied\.)?(?: Cannot resolve PTR record for (\d+\.){3}\d+))$
 
 failregex = %(cmnfailre)s
             <mdre-<mode>>
@@ -64,6 +71,8 @@ journalmatch = SYSLOG_IDENTIFIER=sm-mta + _SYSTEMD_UNIT=sendmail.service
 # Note the capture <F-MLFID>, includes both the __prefix_lines (which includes
 # the sendmail PID), but also the `\w{14}` which the the sendmail assigned 
 # mail ID (todo: check this is necessary, possible obsolete).
+# Avoid moving <F-MLFID> into the entire prefregex because the grouped messages we 
+# need have different syslog levels (info vs notice) that break the group if BSD verbose format is set
 #
 # Author: Daniel Black, Fabian Wenk and Sergey Brester aka sebres.
 # Rewritten using prefregex by Serg G. Brester.

--- a/filter.d/slapd.conf
+++ b/filter.d/slapd.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2023/10/18
 # slapd (Stand-alone LDAP Daemon) openldap daemon filter
 #
 # Detecting invalid credentials: error code 49
@@ -14,13 +14,11 @@ before = common.conf
 
 _daemon = slapd
 
-failregex = ^(?P<__prefix>%(__prefix_line)s)conn=(?P<_conn_>\d+) fd=\d+ ACCEPT from IP=<HOST>:\d{1,5} \(IP=\S+\)\s*<SKIPLINES>(?P=__prefix)conn=(?P=_conn_) op=\d+ RESULT(?:\s(?!err)\S+=\S*)* err=49 text=[\w\s]*$
+prefregex = ^%(__prefix_line)sconn=<F-MLFID>\d+</F-MLFID>(?: (?:fd|op)=\d+){0,2} (?=ACCEPT|RESULT)<F-CONTENT>.+</F-CONTENT>$
+
+failregex = ^<F-NOFAIL>ACCEPT</F-NOFAIL> from IP=<ADDR>:\d{1,5}\s+
+            ^RESULT(?:\s(?!err)\S+=\S*)* err=49\b
 
 ignoreregex =
 
-[Init]
-
-# "maxlines" is number of log lines to buffer for multi-line regex searches
-maxlines = 20
-
-# Author: Andrii Melnyk
+# Author: Andrii Melnyk, Sergey G. Brester

--- a/filter.d/sogo-auth.conf
+++ b/filter.d/sogo-auth.conf
@@ -1,5 +1,5 @@
-## Version 2022/08/06
-# Fail2ban filter for SOGo authentcation
+## Version 2023/11/18
+# Fail2ban filter for SOGo authentication
 #
 # Log file usually in /var/log/sogo/sogo.log
 

--- a/filter.d/sshd.conf
+++ b/filter.d/sshd.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2024/12/26
 # Fail2Ban filter for openssh
 #
 # If you want to protect OpenSSH from being bruteforced by password
@@ -17,7 +17,7 @@ before = common.conf
 
 [DEFAULT]
 
-_daemon = sshd
+_daemon = sshd(?:-session)?
 
 # optional prefix (logged from several ssh versions) like "error: ", "error: PAM: " or "fatal: "
 __pref = (?:(?:error|fatal): (?:PAM: )?)?
@@ -25,8 +25,8 @@ __pref = (?:(?:error|fatal): (?:PAM: )?)?
 #__suff = (?: port \d+)?(?: \[preauth\])?\s*
 __suff = (?: (?:port \d+|on \S+|\[preauth\])){0,3}\s*
 __on_port_opt = (?: (?:port \d+|on \S+)){0,2}
-# close by authenticating user:
-__authng_user = (?: (?:invalid|authenticating) user <F-USER>\S+|.*?</F-USER>)?
+# close by authenticating user (don't use <HOST> after %(__authng_user)s because of catch-all `.*?`):
+__authng_user = (?: (?:by|from))?(?: (?:invalid|authenticating) user <F-USER>\S+|.*?</F-USER>)?(?: from)?
 
 # for all possible (also future) forms of "no matching (cipher|mac|MAC|compression method|key exchange method|host key type) found",
 # see ssherr.c for all possible SSH_ERR_..._ALG_MATCH errors.
@@ -39,21 +39,21 @@ __pam_auth = pam_[a-z]+
 
 prefregex = ^<F-MLFID>%(__prefix_line)s</F-MLFID>%(__pref)s<F-CONTENT>.+</F-CONTENT>$
 
-cmnfailre = ^[aA]uthentication (?:failure|error|failed) for <F-USER>.*</F-USER> from <HOST>( via \S+)?%(__suff)s$
-            ^User not known to the underlying authentication module for <F-USER>.*</F-USER> from <HOST>%(__suff)s$
+cmnfailre = ^[aA]uthentication (?:failure|error|failed) for <F-USER>.*?</F-USER> (?:from )?<HOST>( via \S+)?%(__suff)s$
+            ^User not known to the underlying authentication module for <F-USER>.*?</F-USER> (?:from )?<HOST>%(__suff)s$
             <cmnfailre-failed-pub-<publickey>>
             ^Failed <cmnfailed> for (?P<cond_inv>invalid user )?<F-USER>(?P<cond_user>\S+)|(?(cond_inv)(?:(?! from ).)*?|[^:]+)</F-USER> from <HOST>%(__on_port_opt)s(?: ssh\d*)?(?(cond_user): |(?:(?:(?! from ).)*)$)
             ^<F-USER>ROOT</F-USER> LOGIN REFUSED FROM <HOST>
-            ^[iI](?:llegal|nvalid) user <F-USER>.*?</F-USER> from <HOST>%(__suff)s$
-            ^User <F-USER>\S+|.*?</F-USER> from <HOST> not allowed because not listed in AllowUsers%(__suff)s$
-            ^User <F-USER>\S+|.*?</F-USER> from <HOST> not allowed because listed in DenyUsers%(__suff)s$
-            ^User <F-USER>\S+|.*?</F-USER> from <HOST> not allowed because not in any group%(__suff)s$
+            ^[iI](?:llegal|nvalid) user <F-USER>.*?</F-USER> (?:from )?<HOST>%(__suff)s$
+            ^User <F-USER>\S+|.*?</F-USER> (?:from )?<HOST> not allowed because not listed in AllowUsers%(__suff)s$
+            ^User <F-USER>\S+|.*?</F-USER> (?:from )?<HOST> not allowed because listed in DenyUsers%(__suff)s$
+            ^User <F-USER>\S+|.*?</F-USER> (?:from )?<HOST> not allowed because not in any group%(__suff)s$
             ^refused connect from \S+ \(<HOST>\)
             ^Received <F-MLFFORGET>disconnect</F-MLFFORGET> from <HOST>%(__on_port_opt)s:\s*3: .*: Auth fail%(__suff)s$
-            ^User <F-USER>\S+|.*?</F-USER> from <HOST> not allowed because a group is listed in DenyGroups%(__suff)s$
-            ^User <F-USER>\S+|.*?</F-USER> from <HOST> not allowed because none of user's groups are listed in AllowGroups%(__suff)s$
+            ^User <F-USER>\S+|.*?</F-USER> (?:from )?<HOST> not allowed because a group is listed in DenyGroups%(__suff)s$
+            ^User <F-USER>\S+|.*?</F-USER> (?:from )?<HOST> not allowed because none of user's groups are listed in AllowGroups%(__suff)s$
             ^<F-NOFAIL>%(__pam_auth)s\(sshd:auth\):\s+authentication failure;</F-NOFAIL>(?:\s+(?:(?:logname|e?uid|tty)=\S*)){0,4}\s+ruser=<F-ALT_USER>\S*</F-ALT_USER>\s+rhost=<HOST>(?:\s+user=<F-USER>\S*</F-USER>)?%(__suff)s$
-            ^maximum authentication attempts exceeded for <F-USER>.*</F-USER> from <HOST>%(__on_port_opt)s(?: ssh\d*)?%(__suff)s$
+            ^maximum authentication attempts exceeded for (?:invalid user )?<F-USER>.*?</F-USER> (?:from )?<HOST>%(__on_port_opt)s(?: ssh\d*)?%(__suff)s$
             ^User <F-USER>\S+|.*?</F-USER> not allowed because account is locked%(__suff)s
             ^<F-MLFFORGET>Disconnecting</F-MLFFORGET>(?: from)?(?: (?:invalid|authenticating)) user <F-USER>\S+</F-USER> <HOST>%(__on_port_opt)s:\s*Change of username or service not allowed:\s*.*\[preauth\]\s*$
             ^Disconnecting: Too many authentication failures(?: for <F-USER>\S+|.*?</F-USER>)?%(__suff)s$
@@ -69,24 +69,25 @@ cmnfailed = <cmnfailed-<publickey>>
 
 mdre-normal =
 # used to differentiate "connection closed" with and without `[preauth]` (fail/nofail cases in ddos mode)
-mdre-normal-other = ^<F-NOFAIL><F-MLFFORGET>(Connection (?:closed|reset)|Disconnected)</F-MLFFORGET></F-NOFAIL> (?:by|from)%(__authng_user)s <HOST>(?:%(__suff)s|\s*)$
+mdre-normal-other = ^<F-NOFAIL><F-MLFFORGET>(?:Connection (?:closed|reset)|Disconnect(?:ed|ing))</F-MLFFORGET></F-NOFAIL>%(__authng_user)s <ADDR>%(__on_port_opt)s(?:: (?!Too many authentication failures)[^\[]+)?(?: \[preauth\])?\s*$
 
-mdre-ddos = ^Did not receive identification string from <HOST>
+mdre-ddos = ^(?:Did not receive identification string from|Timeout before authentication for(?: connection from)?) <HOST>
             ^kex_exchange_identification: (?:read: )?(?:[Cc]lient sent invalid protocol identifier|[Cc]onnection (?:closed by remote host|reset by peer))
-            ^Bad protocol version identification '.*' from <HOST>
+            ^Bad protocol version identification '(?:[^']|.*?)' (?:from )?<HOST>%(__suff)s$
             ^<F-NOFAIL>SSH: Server;Ltype:</F-NOFAIL> (?:Authname|Version|Kex);Remote: <HOST>-\d+;[A-Z]\w+:
             ^Read from socket failed: Connection <F-MLFFORGET>reset</F-MLFFORGET> by peer
-            ^banner exchange: Connection from <HOST><__on_port_opt>: invalid format
+            ^(?:banner exchange|ssh_dispatch_run_fatal): Connection from <HOST><__on_port_opt>: (?:invalid format|(?:message authentication code incorrect|[Cc]onnection corrupted) \[preauth\])
+
 # same as mdre-normal-other, but as failure (without <F-NOFAIL> with [preauth] and with <F-NOFAIL> on no preauth phase as helper to identify address):
-mdre-ddos-other = ^<F-MLFFORGET>(Connection (?:closed|reset)|Disconnected)</F-MLFFORGET> (?:by|from)%(__authng_user)s <HOST>%(__on_port_opt)s\s+\[preauth\]\s*$
-                  ^<F-NOFAIL><F-MLFFORGET>(Connection (?:closed|reset)|Disconnected)</F-MLFFORGET></F-NOFAIL> (?:by|from)%(__authng_user)s <HOST>(?:%(__on_port_opt)s|\s*)$
+mdre-ddos-other = ^<F-MLFFORGET>(?:Connection (?:closed|reset)|Disconnect(?:ed|ing))</F-MLFFORGET>%(__authng_user)s <ADDR>%(__on_port_opt)s(?:: (?!Too many authentication failures)[^\[]+)?\s+\[preauth\]\s*$
+                  ^<F-NOFAIL><F-MLFFORGET>(?:Connection (?:closed|reset)|Disconnect(?:ed|ing))</F-MLFFORGET></F-NOFAIL>%(__authng_user)s <ADDR>(?:%(__on_port_opt)s(?:: (?!Too many authentication failures)[^\[]+)?|\s*)$
 
 mdre-extra = ^Received <F-MLFFORGET>disconnect</F-MLFFORGET> from <HOST>%(__on_port_opt)s:\s*14: No(?: supported)? authentication methods available
             ^Unable to negotiate with <HOST>%(__on_port_opt)s: no matching <__alg_match> found.
             ^Unable to negotiate a <__alg_match>
             ^no matching <__alg_match> found:
 # part of mdre-ddos-other, but user name is supplied (invalid/authenticating) on [preauth] phase only:
-mdre-extra-other = ^<F-MLFFORGET>Disconnected</F-MLFFORGET>(?: from)?(?: (?:invalid|authenticating)) user <F-USER>\S+|.*?</F-USER> <HOST>%(__on_port_opt)s \[preauth\]\s*$
+mdre-extra-other = ^<F-MLFFORGET>Disconnected</F-MLFFORGET>(?: from)?(?: (?:invalid|authenticating)) user <F-USER>\S+|.*?</F-USER> (?:from )?<HOST>%(__on_port_opt)s \[preauth\]\s*$
 
 mdre-aggressive = %(mdre-ddos)s
                   %(mdre-extra)s
@@ -126,7 +127,7 @@ ignoreregex =
 
 maxlines = 1
 
-journalmatch = _SYSTEMD_UNIT=sshd.service + _COMM=sshd
+journalmatch = _SYSTEMD_UNIT=sshd.service + _COMM=sshd + _COMM=sshd-session
 
 # DEV Notes:
 #

--- a/filter.d/traefik-auth.conf
+++ b/filter.d/traefik-auth.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2023/11/18
 # Fail2ban filter configuration for traefik :: auth
 # used to ban hosts, that were failed through traefik
 #
@@ -6,7 +6,7 @@
 #
 # To use 'traefik-auth' filter you have to configure your Traefik instance to write
 # the access logs as describe in https://docs.traefik.io/configuration/logs/#access-logs
-# into a log file on host and specifiy users for Basic Authentication
+# into a log file on host and specify users for Basic Authentication
 # https://docs.traefik.io/configuration/entrypoints/#basic-authentication
 #
 # Example:
@@ -52,7 +52,7 @@
 
 [Definition]
 
-# Parameter "method" can be used to specifiy request method
+# Parameter "method" can be used to specify request method
 req-method = \S+
 # Usage example (for jail.local):
 #   filter = traefik-auth[req-method="GET|POST|HEAD"]

--- a/filter.d/vaultwarden.conf
+++ b/filter.d/vaultwarden.conf
@@ -1,0 +1,9 @@
+## Version 2025/07/31
+# Fail2Ban filter for unsuccessful Vaultwarden authentication attempts
+# Logged in /var/log/vaultwarden.log
+# Author: LearningSpot
+
+[Definition]
+
+failregex = ^\s*(?:\[\]\s*)?\[vaultwarden::api::(?:identity|admin|core::two_factor::authenticator)?\]\[ERROR\] (?:Invalid admin token|Invalid TOTP code|Username or password is incorrect)[\.!](?:\s+(?!IP:)\S+)* IP: <ADDR>(?:\. Username: <F-USER>\S+</F-USER>)?
+ignoreregex =

--- a/filter.d/vsftpd.conf
+++ b/filter.d/vsftpd.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2025/03/04
 # Fail2Ban filter for vsftp
 #
 # Configure VSFTP for "dual_log_enable=YES", and have fail2ban watch
@@ -11,13 +11,13 @@ before = common.conf
 
 [Definition]
 
-__pam_re=\(?%(__pam_auth)s(?:\(\S+\))?\)?:?
+__pam_re=(?:\(?%(__pam_auth)s(?:\(\S+\))?\)?:?\s+)?
 _daemon =  vsftpd
 
-failregex = ^%(__prefix_line)s%(__pam_re)s\s+authentication failure; logname=\S* uid=\S* euid=\S* tty=(ftp)? ruser=\S* rhost=<HOST>(?:\s+user=.*)?\s*$
-            ^ \[pid \d+\] \[[^\]]+\] FAIL LOGIN: Client "<HOST>"(?:\s*$|,)
+failregex = ^%(__prefix_line)s%(__pam_re)sauthentication failure; logname=<F-ALT_USER1>\S*</F-ALT_USER1> uid=\S* euid=\S* tty=(?:ftp)? ruser=<F-USER>\S*</F-USER> rhost=<HOST>(?:\s+user=<F-ALT_USER>\S*</F-ALT_USER>)?\s*$
+            ^(?:\s*\[pid \d+\] |%(__prefix_line)s)\[<F-USER>[^\]]+</F-USER>\] FAIL LOGIN: Client "<HOST>"(?:\s*$|,)
 
-ignoreregex = 
+ignoreregex =
 
-# Author: Cyril Jaquier
+# Authors: Cyril Jaquier, Lucian Maly <lmaly@redhat.com>
 # Documentation from fail2ban wiki

--- a/jail.conf
+++ b/jail.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2025/04/01
 #
 # WARNING: heavily refactored in 0.9.0 release.  Please review and
 #          customize settings for your setup.
@@ -99,7 +99,9 @@ before = paths-lsio.conf
 # ignorecommand = /path/to/command <ip>
 ignorecommand =
 
-# "bantime" is the number of seconds that a host is banned.
+# "bantime" is the amount of time that a host is banned, integer in seconds or
+# time abbreviation format (m - minutes, h - hours, d - days, w - weeks, mo - months, y - years).
+# This is to consider as an initial time if bantime.increment gets enabled.
 bantime  = 10m
 
 # A host is banned if it has generated "maxretry" during the last "findtime"
@@ -113,19 +115,17 @@ maxretry = 5
 maxmatches = %(maxretry)s
 
 # "backend" specifies the backend used to get files modification.
-# Available options are "pyinotify", "gamin", "polling", "systemd" and "auto".
+# Available options are "pyinotify", "polling", "systemd" and "auto".
 # This option can be overridden in each jail as well.
 #
 # pyinotify: requires pyinotify (a file alteration monitor) to be installed.
 #              If pyinotify is not installed, Fail2ban will use auto.
-# gamin:     requires Gamin (a file alteration monitor) to be installed.
-#              If Gamin is not installed, Fail2ban will use auto.
 # polling:   uses a polling algorithm which does not require external libraries.
 # systemd:   uses systemd python library to access the systemd journal.
 #              Specifying "logpath" is not valid for this backend.
 #              See "journalmatch" in the jails associated filter config
 # auto:      will try to use the following backends, in order:
-#              pyinotify, gamin, polling.
+#              pyinotify, polling.
 #
 # Note: if systemd backend is chosen as the default but you enable a jail
 #       for which logs are present only in its own log files, specify some other
@@ -207,8 +207,8 @@ fail2ban_agent = Fail2Ban/%(fail2ban_version)s
 # iptables-multiport, shorewall, etc) It is used to define
 # action_* variables. Can be overridden globally or per
 # section within jail.local file
-banaction = iptables-multiport
-banaction_allports = iptables-allports
+#banaction = iptables-multiport
+#banaction_allports = iptables-allports
 
 # The simplest action to take: ban only
 action_ = %(banaction)s[port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]

--- a/jail.d/mongodb-auth.conf
+++ b/jail.d/mongodb-auth.conf
@@ -1,0 +1,9 @@
+## Version 2016/11/10
+# Log wrong MongoDB auth (for details see filter 'filter.d/mongodb-auth.conf')
+# change port when running with "--shardsvr" or "--configsvr" runtime operation
+
+[mongodb-auth]
+
+enabled = false
+port    = 27017
+logpath = %(remote_logs_path)s/mongodb/mongodb.log

--- a/jail.d/mssql-auth.conf
+++ b/jail.d/mssql-auth.conf
@@ -1,0 +1,10 @@
+## Version 2020/02/24
+# Default configuration for Microsoft SQL Server for Linux
+# See the 'mssql-conf' manpage how to change logpath or port
+
+[mssql-auth]
+
+enabled = false
+logpath = %(remote_logs_path)s/mssql/log/errorlog
+port    = 1433
+filter  = mssql-auth

--- a/jail.d/mysqld-auth.conf
+++ b/jail.d/mysqld-auth.conf
@@ -1,0 +1,14 @@
+## Version 2025/01/30
+# To log wrong MySQL access attempts add to /etc/my.cnf in [mysqld] or
+# equivalent section:
+#   log_error_verbosity = 3
+# for older versions:
+#   log-warnings = 2
+# Also check whether `log_error` (or `log-error`) system variable match the `logpath`.
+
+[mysqld-auth]
+
+enabled = false
+port    = 3306
+logpath = %(mysql_log)s
+backend = %(mysql_backend)s

--- a/jail.d/nginx-forbidden.conf
+++ b/jail.d/nginx-forbidden.conf
@@ -1,0 +1,9 @@
+## Version 2023/03/23
+# Fail2Ban jail configuration for nginx forbidden
+# Works OOTB with defaults
+
+[nginx-forbidden]
+
+enabled = false
+port    = http,https
+logpath = %(nginx_error_log)s

--- a/jail.d/openvpn.conf
+++ b/jail.d/openvpn.conf
@@ -1,0 +1,8 @@
+## Version 2025/01/29
+# Fail2Ban jail configuration for openvpn
+
+[openvpn]
+
+enabled = false
+port    = 443
+logpath = %(logs_path)s/syslog

--- a/jail.d/recidive.conf
+++ b/jail.d/recidive.conf
@@ -1,0 +1,17 @@
+## Version 2025/01/30
+# Jail for more extended banning of persistent abusers
+# !!! WARNINGS !!!
+# 1. Make sure that your loglevel specified in fail2ban.conf/.local
+#    is not at DEBUG level -- which might then cause fail2ban to fall into
+#    an infinite loop constantly feeding itself with non-informative lines
+# 2. Increase dbpurgeage defined in fail2ban.conf to e.g. 648000 (7.5 days)
+#    to maintain entries for failed logins for sufficient amount of time
+
+[recidive]
+
+enabled   = false
+# lsio value
+logpath = /config/log/fail2ban/fail2ban.log
+banaction = %(banaction_allports)s
+bantime   = 1w
+findtime  = 1d

--- a/jail.d/routeros-auth.conf
+++ b/jail.d/routeros-auth.conf
@@ -1,0 +1,7 @@
+## Version 2023/02/28
+
+[routeros-auth]
+
+enabled = false
+port    = ssh,http,https
+logpath = %(remote_logs_path)s/MikroTik/router.log

--- a/jail.d/vaultwarden.conf
+++ b/jail.d/vaultwarden.conf
@@ -1,0 +1,7 @@
+## Version 2025/04/01
+
+[vaultwarden]
+
+enabled = false
+port    = http,https
+logpath = %(remote_logs_path)s/vaultwarden.log

--- a/paths-common.conf
+++ b/paths-common.conf
@@ -1,4 +1,4 @@
-## Version 2022/08/06
+## Version 2025/01/30
 # Common
 #
 
@@ -71,7 +71,7 @@ proftpd_backend = %(default_backend)s
 pureftpd_log = %(syslog_ftp)s
 pureftpd_backend = %(default_backend)s
 
-# ftp, daemon and then local7 are tried at configure time however it is overwriteable at configure time
+# ftp, daemon and then local7 are tried at configure time however it is overwritable at configure time
 #
 wuftpd_log = %(syslog_ftp)s
 wuftpd_backend = %(default_backend)s
@@ -91,7 +91,12 @@ dovecot_backend = %(default_backend)s
 # Seems to be set at compile time only to LOG_LOCAL0 (src/const.h) at Notice level
 solidpop3d_log = %(syslog_local0)s
 
-mysql_log = %(syslog_daemon)s
+mysql_log = %(logs_path)s/mariadb/mariadb.log
+            %(logs_path)s/mariadb/error.log
+            %(logs_path)s/mysql/mysqld.log
+            %(logs_path)s/mysql/error.log
+            %(logs_path)s/mysqld.log
+
 mysql_backend = %(default_backend)s
 
 # jail.d/*.conf variables


### PR DESCRIPTION
This PR refreshes the bundled Fail2Ban configuration files in `action.d`, `filter.d`, `jail.d` from [upstream Fail2Ban](https://github.com/fail2ban/fail2ban/tree/master/config) (in sync with the latest commit: https://github.com/fail2ban/fail2ban/commit/26b91862fcb8660f51711d00e8de42c5f046d0dc).

There’s an open issue #35 “Why are the fail2ban configs so outdated?” — this PR addresses that concern by syncing all configs.

closes #35 